### PR TITLE
Explicitly tag merges as transformers models

### DIFF
--- a/mergekit/card.py
+++ b/mergekit/card.py
@@ -165,7 +165,9 @@ def generate_card(
         model_bullets.append("* " + modelref_md(model))
 
     return CARD_TEMPLATE.format(
-        metadata=yaml.dump({"base_model": hf_bases, "tags": tags, "library_name": "transformers"}),
+        metadata=yaml.dump(
+            {"base_model": hf_bases, "tags": tags, "library_name": "transformers"}
+        ),
         model_list="\n".join(model_bullets),
         base_text=base_text,
         merge_method=method_md(config.merge_method),

--- a/mergekit/card.py
+++ b/mergekit/card.py
@@ -165,7 +165,7 @@ def generate_card(
         model_bullets.append("* " + modelref_md(model))
 
     return CARD_TEMPLATE.format(
-        metadata=yaml.dump({"base_model": hf_bases, "tags": tags}),
+        metadata=yaml.dump({"base_model": hf_bases, "tags": tags, "library_name": "transformers"}),
         model_list="\n".join(model_bullets),
         base_text=base_text,
         merge_method=method_md(config.merge_method),


### PR DESCRIPTION
At the moment, `mergekit` models are not explicitly tagged as `transformers` ([example](https://huggingface.co/seyf1elislam/Kunai-Hermes-7b)). They still show the `transformers` tag as they have a `config.json`, which for legacy reasons, is used to tag repos implicitly. Going forward, we're tagging libraries explicitly in the metadata.