### PR TITLE
Inter-architecture weights mapping

### DIFF
--- a/mergekit/_data/mappings/a_b.json
+++ b/mergekit/_data/mappings/a_b.json
@@ -1,0 +1,12 @@
+{
+    "start_architectures": ["A"],
+    "destination_architectures": ["B"],
+    "pre_weights_mapping":{
+        "start" : ["a", "b", "c"],
+        "destination" : ["x", "y", "z"]
+    },
+    "post_weights_mapping":{
+        "start" : ["d", "e", "f"],
+        "destination" : ["m", "n", "o"]
+    }
+}

--- a/mergekit/_data/mappings/a_b.json
+++ b/mergekit/_data/mappings/a_b.json
@@ -1,12 +1,9 @@
 {
     "start_architectures": ["A"],
     "destination_architectures": ["B"],
-    "pre_weights_mapping":{
-        "start" : ["a", "b", "c"],
-        "destination" : [null, "y", "z"]
-    },
-    "post_weights_mapping":{
-        "start" : ["d", "e", "f"],
-        "destination" : ["m", null, null]
+    "weights_mapping":{
+        "a" : "d",
+        "b" : "e",
+        "c" : "m"
     }
 }

--- a/mergekit/_data/mappings/a_b.json
+++ b/mergekit/_data/mappings/a_b.json
@@ -3,10 +3,10 @@
     "destination_architectures": ["B"],
     "pre_weights_mapping":{
         "start" : ["a", "b", "c"],
-        "destination" : ["x", "y", "z"]
+        "destination" : [null, "y", "z"]
     },
     "post_weights_mapping":{
         "start" : ["d", "e", "f"],
-        "destination" : ["m", "n", "o"]
+        "destination" : ["m", null, null]
     }
 }

--- a/mergekit/architecture.py
+++ b/mergekit/architecture.py
@@ -190,7 +190,7 @@ class ConfiguredArchitectureInfo(BaseModel, frozen=True, arbitrary_types_allowed
             if detect_layer_template(k):
                 if not detect_layer_template(v):
                     raise RuntimeError(
-                        f"Usage of mapping requires one-to-one mapping between architectures. A template was found in {k} but not in {v}"
+                        f"Cross-architecture merging requires one-to-one mapping between architectures. A template was found in {k} but not in {v}"
                     )
 
                 for layer_idx in range(self.num_layers()):
@@ -199,7 +199,7 @@ class ConfiguredArchitectureInfo(BaseModel, frozen=True, arbitrary_types_allowed
                     ] = _template_substitution(v, self.config, layer_idx)
             elif detect_layer_template(v):
                 raise RuntimeError(
-                    f"Usage requires one-to-one mapping for {k} and {v}. A template was found in {v} but not in {k}"
+                    f"Cross-architecture merging requires one-to-one mapping between architectures. A template was found in {v} but not in {k}"
                 )
             else:
                 new_overrides[

--- a/mergekit/architecture.py
+++ b/mergekit/architecture.py
@@ -188,10 +188,8 @@ class ConfiguredArchitectureInfo(BaseModel, frozen=True, arbitrary_types_allowed
     def all_weights(self) -> List[WeightInfo]:
         return self.info.all_weights(self.config)
 
-    def update_overrides(
-        self, overrides: Dict[str, str]
-    ) -> "ConfiguredArchitectureInfo":
-        # NOTE: this makes sure strings in overrides if templates are filled in
+    def set_overrides(self, overrides: Dict[str, str]) -> "ConfiguredArchitectureInfo":
+        # NOTE: this makes sure template strings in overrides are filled in
         overrides = {
             self.info._substitute(k, self.config): self.info._substitute(v, self.config)
             for k, v in overrides.items()
@@ -253,7 +251,7 @@ class JsonArchitectureInfo(ArchitectureInfo, BaseModel, frozen=True):
                 )
         return type(item).model_validate(obj_dict)
 
-    def pre_weights(self, config: PretrainedConfig) -> List[Optional[WeightInfo]]:
+    def pre_weights(self, config: PretrainedConfig) -> List[WeightInfo]:
         weights = [
             self._substitute(wi, config=config) for wi in self.definition.pre_weights
         ]
@@ -266,7 +264,7 @@ class JsonArchitectureInfo(ArchitectureInfo, BaseModel, frozen=True):
             for wi in self.definition.layer_templates.weights
         ]
 
-    def post_weights(self, config: PretrainedConfig) -> Optional[WeightInfo]:
+    def post_weights(self, config: PretrainedConfig) -> List[WeightInfo]:
         weights = [
             self._substitute(wi, config=config) for wi in self.definition.post_weights
         ]

--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -282,4 +282,4 @@ def zip_remove_nones(*args) -> List[List[Any]]:
 
 
     """
-    return [[element for element in t if element is not None] for t in zip(args)]
+    return [[element for element in t if element is not None] for t in zip(*args)]

--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -271,3 +271,15 @@ class ImmutableMap(Generic[T_K, T_V]):
 
     def values(self) -> Iterator[T_V]:
         return self.data.values()
+
+
+def zip_remove_nones(*args) -> List[List[Any]]:
+    """
+    Example:
+
+    >>> zip_remove_nones([1, None, 3], [2, 5, 6], [None, None, 7])
+    [[1, 2], [5], [3, 6, 7]]
+
+
+    """
+    return [[element for element in t if element is not None] for t in zip(args)]

--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -273,13 +273,24 @@ class ImmutableMap(Generic[T_K, T_V]):
         return self.data.values()
 
 
-def zip_remove_nones(*args) -> List[List[Any]]:
+def zip_remove_nones(keys: List[Any], *args) -> List[Tuple[List[Any], List[Any]]]:
     """
     Example:
 
-    >>> zip_remove_nones([1, None, 3], [2, 5, 6], [None, None, 7])
-    [[1, 2], [5], [3, 6, 7]]
-
+    >>> zip_remove_nones(['a','b','c'], [1, None, 3], [2, 5, 6], [None, None, 7])
+    [
+     (['a','b'], [1,2]),
+     (['b'], [5]),
+     (['a','b','c'], [3, 6, 7])
+    ]
 
     """
-    return [[element for element in t if element is not None] for t in zip(*args)]
+    result = []
+
+    for zipped in zip(*args):
+        r = [(k, v) for k, v in zip(keys, zipped) if v is not None]
+        _keys = [k for k, v in r]
+        _values = [v for k, v in r]
+        result.append((_keys, _values))
+
+    return result

--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -271,26 +271,3 @@ class ImmutableMap(Generic[T_K, T_V]):
 
     def values(self) -> Iterator[T_V]:
         return self.data.values()
-
-
-def zip_remove_nones(keys: List[Any], *args) -> List[Tuple[List[Any], List[Any]]]:
-    """
-    Example:
-
-    >>> zip_remove_nones(['a','b','c'], [1, None, 3], [2, 5, 6], [None, None, 7])
-    [
-     (['a','b'], [1,2]),
-     (['b'], [5]),
-     (['a','b','c'], [3, 6, 7])
-    ]
-
-    """
-    result = []
-
-    for zipped in zip(*args):
-        r = [(k, v) for k, v in zip(keys, zipped) if v is not None]
-        _keys = [k for k, v in r]
-        _values = [v for k, v in r]
-        result.append((_keys, _values))
-
-    return result

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -75,10 +75,17 @@ def run_merge(
 
     if merge_config.align_weights:
         new_model_arch_info = [model_arch_info[0]]
+        base_model = model_arch_info[0][1]
         for m, destination_arch_info in model_arch_info[1:]:
-            mapping = JSON_MAPPINGS.get(arch_info.config.architecture, {}).get(
-                destination_arch_info.config.architecture_version
-            )
+            mapping = None
+            for arch in base_model.config.architectures:
+                for destination_arch in destination_arch_info.config.architectures:
+                    mapping = JSON_MAPPINGS.get(arch, {}).get(destination_arch)
+                    if mapping:
+                        break
+                if mapping:
+                    break
+
             if mapping:
                 new_model_arch_info.append(
                     (m, destination_arch_info.update_overrides(mapping))

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -68,7 +68,7 @@ def run_merge(
     logging.info("Planning operations")
     targets = MergePlanner(
         merge_config,
-        arch_info,
+        model_arch_info,
         out_path=out_path,
         options=options,
         out_model_config=cfg_out,
@@ -159,6 +159,7 @@ def _model_out_config(
         res.torch_dtype = config.dtype
 
     try:
+        print(config.slices)
         num_layers = sum(
             s.sources[0].layer_range[1] - s.sources[0].layer_range[0]
             for s in config.slices

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -54,7 +54,7 @@ def run_merge(
             info=get_architecture_info(
                 m.config(trust_remote_code=options.trust_remote_code)
             ),
-            config=m.model.config(trust_remote_code=options.trust_remote_code)
+            config=m.config(trust_remote_code=options.trust_remote_code)
             )
     for m in merge_config.referenced_models()
     }

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -60,7 +60,7 @@ def run_merge(
         for m in merge_config.referenced_models()
     ]
 
-    if not options.allow_crimes:
+    if not (options.allow_crimes or options.align_weights):
         if not all(
             a[1].info == model_arch_info[0][1].info for a in model_arch_info[1:]
         ):

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -20,7 +20,11 @@ from typing import Optional
 import tqdm
 import transformers
 
-from mergekit.architecture import ArchitectureInfo, get_architecture_info, ConfiguredArchitectureInfo
+from mergekit.architecture import (
+    ArchitectureInfo,
+    ConfiguredArchitectureInfo,
+    get_architecture_info,
+)
 from mergekit.card import generate_card
 from mergekit.config import MergeConfiguration
 from mergekit.graph import Executor
@@ -54,13 +58,12 @@ def run_merge(
             info=get_architecture_info(
                 m.config(trust_remote_code=options.trust_remote_code)
             ),
-            config=m.config(trust_remote_code=options.trust_remote_code)
-            )
-    for m in merge_config.referenced_models()
+            config=m.config(trust_remote_code=options.trust_remote_code),
+        )
+        for m in merge_config.referenced_models()
     }
 
     ## ----------------------------------------------------
-
 
     if not options.allow_crimes:
         if not all(a == model_arch_info[0] for a in model_arch_info[1:]):

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -25,7 +25,7 @@ from mergekit.architecture import (
     ConfiguredArchitectureInfo,
     WeightInfo,
 )
-from mergekit.common import ImmutableMap, ModelReference
+from mergekit.common import ImmutableMap, ModelReference, zip_remove_nones
 from mergekit.config import (
     ConfigReader,
     InputSliceDefinition,
@@ -264,7 +264,7 @@ class MergePlanner:
                 self._space_planner.add_procedural_space(space)
 
         models_ = [s.model for s in self.config.slices[0].sources]
-        for weight_infos in zip(
+        for weight_infos in zip_remove_nones(
             *[
                 self.arch_dict[m].info.pre_weights(config=self.out_model_config)
                 for m in models_
@@ -274,7 +274,7 @@ class MergePlanner:
                 weight_infos[0],
                 list(weight_infos),
                 models_,
-                ConfigReader(  # possible trouble here?
+                ConfigReader(
                     config=self.config,
                     t=0,
                     tensor_name=weight_infos[0].name,
@@ -285,7 +285,7 @@ class MergePlanner:
             self.plan_slice(out_slice)
 
         models_ = [s.model for s in self.config.slices[-1].sources]
-        for weight_infos in zip(
+        for weight_infos in zip_remove_nones(
             *[
                 self.arch_dict[m].info.post_weights(config=self.out_model_config)
                 for m in models_

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -120,7 +120,7 @@ class MergePlanner:
 
                 if not (mapping or is_same_arch):
                     raise RuntimeError(
-                        f"For cross architecture merge between architectures {base_config.architectures[0]} and {m_config.architectures[0]}, a mapping must be provided"
+                        f"For cross architecture merge between architectures {base_config.architectures[0]} and {m_config.architectures[0]}, a mapping must be provided in the directory _data/mappings"
                     )
 
             self.arch_dict[m] = configured_arch_info

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -44,7 +44,7 @@ from mergekit.tokenizer import BuildTokenizer
 class MergePlanner:
     config: MergeConfiguration
     arch_info: ArchitectureInfo
-    arch_dict: Dict[str, ConfiguredArchitectureInfo]
+    arch_dict: Dict[ModelReference, ConfiguredArchitectureInfo]
     clone_tensors: bool
     trust_remote_code: bool
     out_model_config: Any
@@ -60,7 +60,7 @@ class MergePlanner:
         config: MergeConfiguration,
         arch_info: ArchitectureInfo,
         arch_dict: Dict[
-            str, ConfiguredArchitectureInfo
+            ModelReference, ConfiguredArchitectureInfo
         ],  # perhaps this should no longer be a disjoint step
         out_path: str,
         options: MergeOptions,
@@ -216,9 +216,7 @@ class MergePlanner:
             config=self.out_model_config,
         )
         weights_in: List[List[WeightInfo]] = [
-            self.arch_dict[s.model.model.path].layer_weights(
-                index=s.layer_range[0] + layer_offset
-            )
+            self.arch_dict[s.model].layer_weights(index=s.layer_range[0] + layer_offset)
             for s in sources
         ]
 
@@ -268,9 +266,7 @@ class MergePlanner:
         models_ = [s.model for s in self.config.slices[0].sources]
         for weight_infos in zip(
             *[
-                self.arch_dict[m.model.path].info.pre_weights(
-                    config=self.out_model_config
-                )
+                self.arch_dict[m].info.pre_weights(config=self.out_model_config)
                 for m in models_
             ]
         ):
@@ -291,9 +287,7 @@ class MergePlanner:
         models_ = [s.model for s in self.config.slices[-1].sources]
         for weight_infos in zip(
             *[
-                self.arch_dict[m.model.path].info.post_weights(
-                    config=self.out_model_config
-                )
+                self.arch_dict[m].info.post_weights(config=self.out_model_config)
                 for m in models_
             ]
         ):

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -216,7 +216,7 @@ class MergePlanner:
             config=self.out_model_config,
         )
         weights_in: List[List[WeightInfo]] = [
-            self.arch_dict(s.model.model.path).layer_weights(
+            self.arch_dict[s.model.model.path].layer_weights(
                 index=s.layer_range[0] + layer_offset
             )
             for s in sources

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -99,18 +99,17 @@ class MergePlanner:
 
             if config.align_weights:
                 mapping = None
-                for arch in base_config.architectures:
-                    for destination_arch in m_config.architectures:
-                        mapping = JSON_MAPPINGS.get(arch, {}).get(destination_arch)
-                        if mapping:
-                            break
+                for arch, destination_arch in [
+                    (arch1, arch2)
+                    for arch1 in base_config.architectures
+                    for arch2 in m_config.architectures
+                ]:
+                    mapping = JSON_MAPPINGS.get(arch, {}).get(destination_arch)
                     if mapping:
+                        configured_arch_info = configured_arch_info.set_overrides(
+                            mapping
+                        )
                         break
-
-                if mapping:
-                    configured_arch_info = configured_arch_info.update_overrides(
-                        mapping
-                    )
 
             self.arch_dict[m] = configured_arch_info
 

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -104,7 +104,7 @@ class MergePlanner:
             base_model = None
 
             for model_in in self.config.models:
-                model_info = self.arch_dict[model_in.model.model.path]
+                model_info = self.arch_dict[model_in.model]
                 slice = InputSliceDefinition(
                     layer_range=[0, model_info.num_layers()],
                     model=model_in.model,
@@ -118,7 +118,7 @@ class MergePlanner:
 
             if self.config.base_model:
                 if not base_model:
-                    base_model_info = self.arch_dict[self.config.base_model.model.path]
+                    base_model_info = self.arch_dict[self.config.base_model]
                     base_model = InputSliceDefinition(
                         layer_range=[0, base_model_info.num_layers()],
                         model=self.config.base_model,

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -291,12 +291,13 @@ class MergePlanner:
 
         models_ = [s.model for s in self.config.slices[-1].sources]
         for models, weight_infos in zip_remove_nones(
+            models_,
             *[
                 self.arch_dict[m].info.post_weights(
                     config=self.out_model_config, overrides=self.arch_dict[m].overrides
                 )
                 for m in models_
-            ]
+            ],
         ):
             self.plan_tensor(
                 weight_infos[0],

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -45,6 +45,7 @@ from mergekit.tokenizer import BuildTokenizer
 
 class MergePlanner:
     arch_dict: Dict[ModelReference, ConfiguredArchitectureInfo]
+    arch_info: ArchitectureInfo
     config: MergeConfiguration
     clone_tensors: bool
     trust_remote_code: bool
@@ -119,7 +120,7 @@ class MergePlanner:
 
                 if not (mapping or is_same_arch):
                     raise RuntimeError(
-                        "For cross architecture merges, a mapping is required!!!"
+                        f"For cross architecture merge between architectures {base_config.architectures[0]} and {m_config.architectures[0]}, a mapping must be provided"
                     )
 
             self.arch_dict[m] = configured_arch_info

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -264,12 +264,26 @@ class MergePlanner:
                 self._space_planner.add_procedural_space(space)
 
         models_ = [s.model for s in self.config.slices[0].sources]
+        print(models_)
+        print(
+            [
+                # TODO: this is wayy too complicated
+                self.arch_dict[m].info.pre_weights(
+                    config=self.out_model_config, overrides=self.arch_dict[m].overrides
+                )
+                for m in models_
+            ]
+        )
         for weight_infos in zip_remove_nones(
             *[
-                self.arch_dict[m].info.pre_weights(config=self.out_model_config)
+                # TODO: this is wayy too complicated
+                self.arch_dict[m].info.pre_weights(
+                    config=self.out_model_config, overrides=self.arch_dict[m].overrides
+                )
                 for m in models_
             ]
         ):
+            print(weight_infos)
             self.plan_tensor(
                 weight_infos[0],
                 list(weight_infos),
@@ -287,7 +301,9 @@ class MergePlanner:
         models_ = [s.model for s in self.config.slices[-1].sources]
         for weight_infos in zip_remove_nones(
             *[
-                self.arch_dict[m].info.post_weights(config=self.out_model_config)
+                self.arch_dict[m].info.post_weights(
+                    config=self.out_model_config, overrides=self.arch_dict[m].overrides
+                )
                 for m in models_
             ]
         ):

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -25,7 +25,7 @@ from mergekit.architecture import (
     ConfiguredArchitectureInfo,
     WeightInfo,
 )
-from mergekit.common import ImmutableMap, ModelReference, zip_remove_nones
+from mergekit.common import ImmutableMap, ModelReference
 from mergekit.config import (
     ConfigReader,
     InputSliceDefinition,
@@ -263,22 +263,18 @@ class MergePlanner:
             for space in self.arch_info.procedural_spaces(config=self.out_model_config):
                 self._space_planner.add_procedural_space(space)
 
-        models_ = [s.model for s in self.config.slices[0].sources]
+        _models = [s.model for s in self.config.slices[0].sources]
 
-        for models, weight_infos in zip_remove_nones(
-            models_,
+        for weight_infos in zip(
             *[
-                # TODO: this is wayy too complicated
-                self.arch_dict[m].info.pre_weights(
-                    config=self.out_model_config, overrides=self.arch_dict[m].overrides
-                )
-                for m in models_
-            ],
+                self.arch_dict[m].info.pre_weights(config=self.out_model_config)
+                for m in _models
+            ]
         ):
             self.plan_tensor(
                 weight_infos[0],
                 list(weight_infos),
-                models,
+                _models,
                 ConfigReader(
                     config=self.config,
                     t=0,
@@ -289,20 +285,17 @@ class MergePlanner:
         for out_slice in self.config.slices:
             self.plan_slice(out_slice)
 
-        models_ = [s.model for s in self.config.slices[-1].sources]
-        for models, weight_infos in zip_remove_nones(
-            models_,
+        _models = [s.model for s in self.config.slices[-1].sources]
+        for weight_infos in zip(
             *[
-                self.arch_dict[m].info.post_weights(
-                    config=self.out_model_config, overrides=self.arch_dict[m].overrides
-                )
-                for m in models_
+                self.arch_dict[m].info.post_weights(config=self.out_model_config)
+                for m in _models
             ],
         ):
             self.plan_tensor(
                 weight_infos[0],
                 list(weight_infos),
-                models,
+                _models,
                 ConfigReader(
                     config=self.config,
                     t=1,

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -264,30 +264,21 @@ class MergePlanner:
                 self._space_planner.add_procedural_space(space)
 
         models_ = [s.model for s in self.config.slices[0].sources]
-        print(models_)
-        print(
-            [
-                # TODO: this is wayy too complicated
-                self.arch_dict[m].info.pre_weights(
-                    config=self.out_model_config, overrides=self.arch_dict[m].overrides
-                )
-                for m in models_
-            ]
-        )
-        for weight_infos in zip_remove_nones(
+
+        for models, weight_infos in zip_remove_nones(
+            models_,
             *[
                 # TODO: this is wayy too complicated
                 self.arch_dict[m].info.pre_weights(
                     config=self.out_model_config, overrides=self.arch_dict[m].overrides
                 )
                 for m in models_
-            ]
+            ],
         ):
-            print(weight_infos)
             self.plan_tensor(
                 weight_infos[0],
                 list(weight_infos),
-                models_,
+                models,
                 ConfigReader(
                     config=self.config,
                     t=0,
@@ -299,7 +290,7 @@ class MergePlanner:
             self.plan_slice(out_slice)
 
         models_ = [s.model for s in self.config.slices[-1].sources]
-        for weight_infos in zip_remove_nones(
+        for models, weight_infos in zip_remove_nones(
             *[
                 self.arch_dict[m].info.post_weights(
                     config=self.out_model_config, overrides=self.arch_dict[m].overrides
@@ -310,7 +301,7 @@ class MergePlanner:
             self.plan_tensor(
                 weight_infos[0],
                 list(weight_infos),
-                models_,
+                models,
                 ConfigReader(
                     config=self.config,
                     t=1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ packages = [
     "mergekit.scripts",
     "mergekit._data",
     "mergekit._data.architectures",
-    "mergekiy._data.mappings",
+    "mergekit._data.mappings",
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ packages = [
     "mergekit.scripts",
     "mergekit._data",
     "mergekit._data.architectures",
+    "mergekiy._data.mappings",
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "typing-extensions",
     "sentencepiece",
     "protobuf",
+    "scipy"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -8,7 +8,7 @@ class TestArchitecture:
     def test_set_overrides(self):
         cfg = AutoConfig.from_pretrained("gpt2")
         arch_info = get_architecture_info(cfg)
-        configured_arch_info = ConfiguredArchitectureInfo(arch_info, cfg)
+        configured_arch_info = ConfiguredArchitectureInfo(info=arch_info, config=cfg)
 
         overrides = {"a_${layer_index}": "b_${layer_index}"}
         new_config = configured_arch_info.set_overrides(overrides)

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,0 +1,16 @@
+import pytest
+from transformers import LlamaConfig
+
+from mergekit.architecture import ConfiguredArchitectureInfo, get_architecture_info
+
+
+class TestArchitecture:
+    def test_set_overrides(self):
+        cfg = LlamaConfig(vocab_size=64, hidden_size=32)
+        arch_info = get_architecture_info(cfg)
+        configured_arch_info = ConfiguredArchitectureInfo(arch_info, cfg)
+
+        overrides = {"a_{layer_index}": "b_layer_{layer_index}"}
+        new_config = configured_arch_info.set_overrides(overrides)
+
+        assert new_config.overrides == overrides

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,16 +1,16 @@
 import pytest
-from transformers import LlamaConfig
+from transformers import AutoConfig, LlamaConfig
 
 from mergekit.architecture import ConfiguredArchitectureInfo, get_architecture_info
 
 
 class TestArchitecture:
     def test_set_overrides(self):
-        cfg = LlamaConfig(vocab_size=64, hidden_size=32)
+        cfg = AutoConfig.from_pretrained("gpt-2")
         arch_info = get_architecture_info(cfg)
         configured_arch_info = ConfiguredArchitectureInfo(arch_info, cfg)
 
-        overrides = {"a_{layer_index}": "b_layer_{layer_index}"}
+        overrides = {"a_${layer_index}": "b_${layer_index}"}
         new_config = configured_arch_info.set_overrides(overrides)
 
-        assert new_config.overrides == overrides
+        assert new_config.overrides == {f"a_{i}": f"b_{i}" for i in range(12)}

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -6,7 +6,7 @@ from mergekit.architecture import ConfiguredArchitectureInfo, get_architecture_i
 
 class TestArchitecture:
     def test_set_overrides(self):
-        cfg = AutoConfig.from_pretrained("gpt-2")
+        cfg = AutoConfig.from_pretrained("gpt2")
         arch_info = get_architecture_info(cfg)
         configured_arch_info = ConfiguredArchitectureInfo(arch_info, cfg)
 


### PR DESCRIPTION
-  [x] Ensure MergePlanner takes into account differing architectures as opposed to how things were previously ( the same architecture was expected of all models to be merged)   

## How does this work?

A mapping is defined as a `json` file between the base model and each model to be merged in. Specifically at the `pre/post` weights level

Each json file corresponds to a base-architecture to destination pair (though the actual direction is the reverse)

an example of this is 

```json

{
    "start_architectures": ["A"],
    "destination_architectures": ["B"],
    "weights_mapping":{
        "a" : "d",
        "b" : "e",
        "c" : "m"
    }
}

```

Notes:
1. string templates are allowed in both keys and values
2. at this time only isomorphic mappings are considered at all levels

  