### PR TITLE
minor fix in mixtral_moe.py for apple silicon

### DIFF
--- a/mergekit/scripts/mixtral_moe.py
+++ b/mergekit/scripts/mixtral_moe.py
@@ -113,7 +113,7 @@ def tokenize_prompts(
     prompts: List[str], tokenizer: transformers.PreTrainedTokenizerBase
 ):
     return tokenizer(
-        [tokenizer.bos_token + p for p in prompts],
+        [str(tokenizer.bos_token) + p for p in prompts],
         return_tensors="pt",
         padding=True,
         add_special_tokens=False,
@@ -366,6 +366,7 @@ def build(
     )
     tokenizer.padding_side = "left"
     tokenizer.pad_token_id = tokenizer.bos_token_id
+    tokenizer.pad_token = tokenizer.eos_token
 
     logging.info("Getting gate parameters...")
     gate_vecs = get_gate_params(

--- a/mergekit/scripts/mixtral_moe.py
+++ b/mergekit/scripts/mixtral_moe.py
@@ -113,7 +113,7 @@ def tokenize_prompts(
     prompts: List[str], tokenizer: transformers.PreTrainedTokenizerBase
 ):
     return tokenizer(
-        [str(tokenizer.bos_token) + p for p in prompts],
+        [tokenizer.bos_token or "" + p for p in prompts],
         return_tensors="pt",
         padding=True,
         add_special_tokens=False,
@@ -366,7 +366,8 @@ def build(
     )
     tokenizer.padding_side = "left"
     tokenizer.pad_token_id = tokenizer.bos_token_id
-    tokenizer.pad_token = tokenizer.eos_token
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
 
     logging.info("Getting gate parameters...")
     gate_vecs = get_gate_params(


### PR DESCRIPTION
There are two fixes that address errors encountered when ran on Apple M2 macbook with Rosetta enabled, not sure if it is a universal problem or specific to my environment (therefore I didn't file an issue due to this uncertainty).

- Fix 1 : cast str type for tokenizer.bos_token, this aims for a fix of persistent weird error `"typeError: unsupported operand type(s) for +: 'NoneType' and 'str'"` although bos_token is indeed str type.

- Fix 2 : add pad_token value, per suggestion of `padding_strategy` raised `ValueError "Asking to pad but the tokenizer does not have a padding token. "` (Line 2708 in transformers/tokenization_utils_base.py)