### PR TITLE
fix tokenize_prompts in moe merge

### DIFF
--- a/mergekit/scripts/mixtral_moe.py
+++ b/mergekit/scripts/mixtral_moe.py
@@ -113,7 +113,7 @@ def tokenize_prompts(
     prompts: List[str], tokenizer: transformers.PreTrainedTokenizerBase
 ):
     return tokenizer(
-        [tokenizer.bos_token or "" + p for p in prompts],
+        [(tokenizer.bos_token or "") + p for p in prompts],
         return_tensors="pt",
         padding=True,
         add_special_tokens=False,


### PR DESCRIPTION
Fixed a problem in which the "or" condition caused incorrect output when tokenizer.bos_token is not None.

```
tokenizer.bos_token='bos_'
prompts=['a', 'b']

[tokenizer.bos_token or "" + p for p in prompts]
```

expect:  ['bos_a', 'bos_b']
Current: ['bos_', 'bos_']