### PR TITLE
Add `mergekit-tokensurgeon`

### DIFF
--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -41,7 +41,7 @@ from pydantic_core import core_schema
 from transformers import AutoConfig, PretrainedConfig
 from typing_extensions import TypeVar
 
-from mergekit.io import ShardedTensorIndex
+from mergekit.io import LazyTensorLoader, ShardedTensorIndex
 
 
 class ModelPath(BaseModel, frozen=True):
@@ -149,6 +149,14 @@ class ModelReference(BaseModel, frozen=True):
             )
 
         return ShardedTensorIndex.from_disk(path)
+
+    def lazy_loader(
+        self, cache_dir: Optional[str] = None, lazy_unpickle: bool = True
+    ) -> LazyTensorLoader:
+        return LazyTensorLoader(
+            self.tensor_index(cache_dir),
+            lazy_unpickle=lazy_unpickle,
+        )
 
     @model_validator(mode="before")
     def validate_string(cls, value):

--- a/mergekit/io/lazy_tensor_loader.py
+++ b/mergekit/io/lazy_tensor_loader.py
@@ -121,7 +121,15 @@ class LazyTensorLoader:
         self.current_shard = None
         self.lazy_unpickle = lazy_unpickle
 
-    def get_tensor(self, key: str, device: str = "cpu") -> Optional[Tensor]:
+    def get_tensor(
+        self, key: str, device: str = "cpu", aliases: Optional[List[str]] = None
+    ) -> Optional[Tensor]:
+        if aliases and key not in self.index.tensor_paths:
+            for alias in aliases:
+                if alias in self.index.tensor_paths:
+                    key = alias
+                    break
+
         if self.current_shard is None or key not in self.current_shard.keys():
             if key not in self.index.tensor_paths:
                 raise KeyError(key)

--- a/mergekit/io/lazy_tensor_loader.py
+++ b/mergekit/io/lazy_tensor_loader.py
@@ -141,3 +141,9 @@ class LazyTensorLoader:
     def flush(self):
         self.current_shard = None
         self.current_keys = None
+
+    @classmethod
+    def from_disk(
+        cls, base_path: str, lazy_unpickle: bool = True
+    ) -> "LazyTensorLoader":
+        return LazyTensorLoader(ShardedTensorIndex.from_disk(base_path), lazy_unpickle)

--- a/mergekit/io/lazy_tensor_loader.py
+++ b/mergekit/io/lazy_tensor_loader.py
@@ -139,7 +139,7 @@ class LazyTensorLoader:
 
             shard_file = self.index.tensor_paths[key]
             shard_full_path = os.path.join(self.index.base_path, shard_file)
-            logging.info(f"Opening shard {shard_full_path}")
+            logging.debug(f"Opening shard {shard_full_path}")
             self.current_shard = TensorLoader.get(
                 shard_full_path, use_lazy_unpickle=self.lazy_unpickle, device=device
             )

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -55,10 +55,7 @@ def run_merge(
 
     # initialize loader cache and set options
     loader_cache = LoaderCache()
-    loader_cache.lazy_unpickle = options.lazy_unpickle
-    loader_cache.lora_cache_dir = options.lora_merge_cache
-    loader_cache.hf_cache_dir = options.transformers_cache
-    loader_cache.trust_remote_code = options.trust_remote_code
+    loader_cache.setup(options=options)
 
     # create config for output model
     cfg_out = _model_out_config(

--- a/mergekit/options.py
+++ b/mergekit/options.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
+import functools
 import typing
 from typing import Any, Callable, Optional, Union
 
@@ -66,6 +67,7 @@ class ShardSizeParamType(click.ParamType):
 
 
 def add_merge_options(f: Callable) -> Callable:
+    @functools.wraps(f)
     def wrapper(*args, **kwargs):
         arg_dict = {}
         for field_name in MergeOptions.model_fields:

--- a/mergekit/scripts/mixtral_moe.py
+++ b/mergekit/scripts/mixtral_moe.py
@@ -141,9 +141,9 @@ def get_gate_params(
             (model_cfg.num_hidden_layers, len(experts), model_cfg.hidden_size)
         )
     elif mode == "cheap_embed":
-        embed = LazyTensorLoader(
-            model_ref.tensor_index(), lazy_unpickle=lazy_unpickle
-        ).get_tensor("model.embed_tokens.weight")
+        embed = model_ref.lazy_loader(lazy_unpickle=lazy_unpickle).get_tensor(
+            "model.embed_tokens.weight"
+        )
 
         def _do_it(tokenized):
             return get_cheap_embedding(
@@ -299,8 +299,8 @@ def build(
     for model in tqdm.tqdm(
         [base_model] + [e.model_ref for e in config.experts], desc="Warm up loaders"
     ):
-        loaders[model] = LazyTensorLoader(
-            model.tensor_index(cache_dir=merge_options.transformers_cache),
+        loaders[model] = model.lazy_loader(
+            cache_dir=merge_options.transformers_cache,
             lazy_unpickle=merge_options.lazy_unpickle,
         )
 

--- a/mergekit/scripts/mixtral_moe.py
+++ b/mergekit/scripts/mixtral_moe.py
@@ -326,7 +326,7 @@ def build(
         base_cfg
     ):
         tensor_name = weight_info.name
-        tensor = base_loader.get_tensor(tensor_name)
+        tensor = base_loader.get_tensor(tensor_name, aliases=weight_info.aliases)
         if not out_dtype:
             # All else has failed, take the first dtype we see
             out_dtype = tensor.dtype
@@ -350,7 +350,9 @@ def build(
                         ".mlp.up_proj", f".block_sparse_moe.experts.{moe_index}.w3"
                     )
                     expert_loader = loaders.get(expert.model_ref)
-                    tensor = expert_loader.get_tensor(tensor_name)
+                    tensor = expert_loader.get_tensor(
+                        tensor_name, aliases=weight_info.aliases
+                    )
                     if expert.noise_scale:
                         tensor += torch.randn_like(tensor) * expert.noise_scale
                     writer.save_tensor(
@@ -358,7 +360,10 @@ def build(
                     )
                 continue
             writer.save_tensor(
-                tensor_name, base_loader.get_tensor(tensor_name).to(dtype=out_dtype)
+                tensor_name,
+                base_loader.get_tensor(tensor_name, aliases=weight_info.aliases).to(
+                    dtype=out_dtype
+                ),
             )
 
     tokenizer = transformers.AutoTokenizer.from_pretrained(

--- a/mergekit/scripts/tokensurgeon.py
+++ b/mergekit/scripts/tokensurgeon.py
@@ -42,19 +42,21 @@ from mergekit.options import MergeOptions, add_merge_options
 @click.option(
     "-k",
     type=int,
-    default=5,
+    default=8,
     help="Number of nearest neighbours to use for embedding interpolation",
 )
 @click.option(
     "--barycentric/--no-barycentric",
+    "-b/-nb",
     is_flag=True,
-    default=False,
-    help="Use barycentric interpolation instead of distance-weighted",
+    default=True,
+    help="Use barycentric interpolation instead of distance weighting",
 )
 @click.option(
     "--cosine-similarity/--no-cosine-similarity",
+    "-c/-nc",
     is_flag=True,
-    default=False,
+    default=True,
     help="Use cosine similarity for nearest neighbour search",
 )
 @add_merge_options

--- a/mergekit/scripts/tokensurgeon.py
+++ b/mergekit/scripts/tokensurgeon.py
@@ -459,18 +459,35 @@ def load_tokenizer(
         revision=model.model.revision,
         trust_remote_code=options.trust_remote_code,
     )
+
+    gpt2_style = [
+        transformers.GPT2Tokenizer,
+        transformers.GPT2TokenizerFast,
+        transformers.OpenAIGPTTokenizer,
+        transformers.OpenAIGPTTokenizerFast,
+    ]
+    for candidate in ["Qwen2Tokenizer", "Qwen2TokenizerFast"]:
+        if hasattr(transformers, candidate):
+            gpt2_style.append(getattr(transformers, candidate))
+
+    sp_style = [
+        transformers.LlamaTokenizer,
+        transformers.LlamaTokenizerFast,
+        transformers.T5Tokenizer,
+        transformers.T5TokenizerFast,
+    ]
+    for candidate in ["GemmaTokenizer", "GemmaTokenizerFast"]:
+        if hasattr(transformers, candidate):
+            sp_style.append(getattr(transformers, candidate))
+
     if isinstance(
         tokenizer,
-        (
-            transformers.GPT2Tokenizer,
-            transformers.OpenAIGPTTokenizer,
-            transformers.GPT2TokenizerFast,
-            transformers.OpenAIGPTTokenizerFast,
-        ),
+        tuple(gpt2_style),
     ):
         word_start_prefix = "Ġ"
     elif isinstance(
-        tokenizer, (transformers.LlamaTokenizer, transformers.LlamaTokenizerFast)
+        tokenizer,
+        tuple(sp_style),
     ):
         word_start_prefix = "▁"
     else:

--- a/mergekit/scripts/tokensurgeon.py
+++ b/mergekit/scripts/tokensurgeon.py
@@ -1,0 +1,207 @@
+# Copyright (C) 2024 Charles O. Goddard
+#
+# This software is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+
+import logging
+import sys
+from typing import Dict, List, Tuple
+
+import click
+import torch
+import transformers
+
+from mergekit.architecture import (
+    ConfiguredArchitectureInfo,
+    WeightInfo,
+    get_architecture_info,
+)
+from mergekit.common import ModelReference
+from mergekit.io import TensorWriter
+from mergekit.io.tasks import LoaderCache
+from mergekit.options import MergeOptions, add_merge_options
+
+
+@click.command("mergekit-tokensurgeon")
+@click.argument("model", type=str)
+@click.argument("donor", type=str)
+@click.argument("out_path", type=str)
+@add_merge_options
+def main(model: str, donor: str, out_path: str, options: MergeOptions):
+    model_ref = ModelReference.model_validate(model)
+    donor_ref = ModelReference.model_validate(donor)
+    replace_tokenizer(model_ref, donor_ref, out_path, options)
+
+
+def replace_tokenizer(
+    model: ModelReference, donor: ModelReference, out_path: str, options: MergeOptions
+):
+    cache = LoaderCache()
+    cache.setup(options=options)
+
+    arch_info = validate_architecture(model, donor, options)
+    embed_info, lm_head_info = get_embedding_info(model, options)
+
+    _, old_vocab = load_tokenizer(model, options)
+    tokenizer, new_vocab = load_tokenizer(donor, options)
+    common_tokens = list(set(old_vocab.keys()) & set(new_vocab.keys()))
+
+    old_embed = cache.get(model).get_tensor(embed_info.name, aliases=embed_info.aliases)
+    donor_embed = cache.get(donor).get_tensor(
+        embed_info.name, aliases=embed_info.aliases
+    )
+
+    (_, hidden_size_0) = old_embed.shape
+    (_, hidden_size_1) = donor_embed.shape
+    if hidden_size_1 != hidden_size_0:
+        report_issue(
+            f"Embedding sizes do not match: {hidden_size_0} vs {hidden_size_1}",
+            error=not options.allow_crimes,
+        )
+
+    min_overlap = max(hidden_size_0, hidden_size_1)
+    if len(common_tokens) < min_overlap:
+        report_issue(
+            f"Common tokens ({len(common_tokens)}) less than embedding size ({min_overlap})",
+            error=not options.allow_crimes,
+        )
+
+    logging.info(
+        f"Computing new embeddings for {len(new_vocab) - len(common_tokens)} tokens"
+    )
+    new_embed = lstsq_embeddings(
+        old_embed, donor_embed, old_vocab, new_vocab, common_tokens
+    )
+    new_lm_head = lstsq_embeddings(
+        cache.get(model).get_tensor(lm_head_info.name, aliases=lm_head_info.aliases),
+        cache.get(donor).get_tensor(lm_head_info.name, aliases=lm_head_info.aliases),
+        old_vocab,
+        new_vocab,
+        common_tokens,
+    )
+
+    # Save out the new model
+    logging.info(f"Saving new model to {out_path}")
+    writer = TensorWriter(
+        out_path,
+        max_shard_size=options.out_shard_size,
+        safe_serialization=options.safe_serialization,
+    )
+    for weight_info in arch_info.all_weights():
+        if weight_info.name == embed_info.name:
+            tensor = new_embed
+        elif weight_info.name == lm_head_info.name:
+            tensor = new_lm_head
+        else:
+            tensor = cache.get(model).get_tensor(
+                weight_info.name, aliases=weight_info.aliases
+            )
+        writer.save_tensor(weight_info.name, tensor, clone=options.clone_tensors)
+    writer.finalize()
+
+    tokenizer.save_pretrained(out_path)
+    arch_info.config.save_pretrained(out_path)
+
+
+def normalize_token(token: str) -> str:
+    if token.startswith("Ġ"):
+        return "▁" + token[1:]
+    return token
+
+
+def get_embedding_info(
+    model: ModelReference, options: MergeOptions
+) -> Tuple[WeightInfo, WeightInfo]:
+    cfg = model.config(trust_remote_code=options.trust_remote_code)
+    arch_info = get_architecture_info(cfg)
+
+    embed, lm_head = None, None
+    for weight_info in arch_info.pre_weights(cfg):
+        if weight_info.is_embed:
+            if embed is not None:
+                raise RuntimeError("Multiple input embeddings found")
+            embed = weight_info
+
+    for weight_info in arch_info.post_weights(cfg):
+        if weight_info.is_embed:
+            if lm_head is not None:
+                raise RuntimeError("Multiple output embeddings found")
+            lm_head = weight_info
+
+    return embed, lm_head
+
+
+def report_issue(message: str, error: bool = False):
+    if error:
+        logging.error(message)
+        sys.exit(1)
+    else:
+        logging.warning(message)
+
+
+def lstsq_embeddings(
+    embed_0: torch.Tensor,
+    embed_1: torch.Tensor,
+    vocab_0: Dict[str, int],
+    vocab_1: Dict[str, int],
+    common_tokens: List[str],
+) -> torch.Tensor:
+    hidden_size_0 = embed_0.shape[1]
+    hidden_size_1 = embed_1.shape[1]
+
+    e_0 = torch.empty(hidden_size_0, len(common_tokens))
+    e_1 = torch.empty(hidden_size_1, len(common_tokens))
+    for i, token in enumerate(common_tokens):
+        e_0[:, i] = embed_0[vocab_0[token]]
+        e_1[:, i] = embed_1[vocab_1[token]]
+
+    M = torch.linalg.lstsq(e_1, e_0).solution
+    new_embed = embed_1 @ M
+    for token in common_tokens:
+        new_embed[vocab_1[token], :] = embed_0[vocab_0[token], :]
+
+    return new_embed
+
+
+def load_tokenizer(
+    model: ModelReference, options: MergeOptions
+) -> Tuple[transformers.PreTrainedTokenizerBase, Dict[str, int]]:
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model.model.path,
+        revision=model.model.revision,
+        trust_remote_code=options.trust_remote_code,
+    )
+    return tokenizer, {
+        normalize_token(token): i for token, i in tokenizer.get_vocab().items()
+    }
+
+
+def validate_architecture(
+    model: ModelReference, donor: ModelReference, options: MergeOptions
+) -> ConfiguredArchitectureInfo:
+    model_cfg = model.config(trust_remote_code=options.trust_remote_code)
+    model_arch_info = get_architecture_info(model_cfg)
+    donor_arch_info = get_architecture_info(
+        donor.config(trust_remote_code=options.trust_remote_code)
+    )
+    if donor_arch_info != model_arch_info:
+        report_issue(
+            f"Model architectures do not match: {model_arch_info} vs {donor_arch_info}",
+            error=not options.allow_crimes,
+        )
+
+    return ConfiguredArchitectureInfo(info=model_arch_info, config=model_cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ mergekit-legacy = "mergekit.scripts.legacy:main"
 mergekit-layershuffle = "mergekit.scripts.layershuffle:main"
 bakllama = "mergekit.scripts.bakllama:main"
 mergekit-moe = "mergekit.scripts.mixtral_moe:main"
+mergekit-tokensurgeon = "mergekit.scripts.tokensurgeon:main"
 
 [tool.setuptools]
 packages = [

--- a/tests/common.py
+++ b/tests/common.py
@@ -31,9 +31,7 @@ def run_and_check_merge(
 
         if check_nan:
             # check for NaN in output
-            loader = LazyTensorLoader(
-                ShardedTensorIndex.from_disk(tmpdir), lazy_unpickle=False
-            )
+            loader = LazyTensorLoader.from_disk(tmpdir, lazy_unpickle=False)
             tp = loader.index.tensor_paths
             sorted_tensors = sorted(tp.keys(), key=lambda k: tp[k])
             for tensor_name in sorted_tensors:

--- a/tests/test_basic_merges.py
+++ b/tests/test_basic_merges.py
@@ -11,7 +11,7 @@ from mergekit.config import (
     OutputSliceDefinition,
     ParameterSetting,
 )
-from mergekit.io import LazyTensorLoader, ShardedTensorIndex
+from mergekit.io import LazyTensorLoader
 
 
 @pytest.fixture(scope="session")
@@ -73,7 +73,7 @@ class TestBasicMerges:
         )
 
         def _check_o_proj(p: str):
-            loader = LazyTensorLoader(index=ShardedTensorIndex.from_disk(p))
+            loader = LazyTensorLoader.from_disk(p)
             saw_any = False
             for name in loader.index.tensor_paths:
                 if "o_proj" in name:

--- a/tests/test_lazy_unpickle.py
+++ b/tests/test_lazy_unpickle.py
@@ -1,6 +1,6 @@
 import torch
 
-from mergekit.io import LazyTensorLoader, ShardedTensorIndex
+from mergekit.io import LazyTensorLoader
 
 
 class TestLazyUnpickle:
@@ -11,9 +11,7 @@ class TestLazyUnpickle:
         }
         path = tmp_path / "pytorch_model.bin"
         torch.save(data, path)
-        loader = LazyTensorLoader(
-            ShardedTensorIndex.from_disk(tmp_path), lazy_unpickle=True
-        )
+        loader = LazyTensorLoader.from_disk(tmp_path)
         for name in data:
             assert name in loader.index.tensor_paths
             tensor = loader.get_tensor(name)


### PR DESCRIPTION
Adds a new script `mergekit-tokensurgeon` that allows replacing a model's tokenizer with one from a different model.

For tokens not present in the original vocabulary, embedding vectors are approximated using the k nearest neighbors among the set of tokens shared by both vocabularies. If your vocabularies are similar enough this can work without any further fine tuning. If they're quite different you will need to do some training, but it'll save a lot of time vs. training the embedding from scratch.