### PR TITLE
Add Model Stock merge method

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ A quick overview of the currently supported merge methods:
 | [DARE](https://arxiv.org/abs/2311.03099) [TIES](https://arxiv.org/abs/2306.01708)            | `dare_ties`          | ✅          | ✅              |
 | [DARE](https://arxiv.org/abs/2311.03099) [Task Arithmetic](https://arxiv.org/abs/2212.04089) | `dare_linear`        | ✅          | ✅              |
 | Passthrough                                                                                  | `passthrough`        | ❌          | ❌              |
+| [Model Stock](https://arxiv.org/abs/2403.19522)                                              | `model_stock`        | ✅          | ✅              |
 
 ### Linear
 
@@ -164,6 +165,14 @@ Parameters: same as [TIES](#ties) for `dare_ties`, or [Linear](#linear) for `dar
 
 `passthrough` is a no-op that simply passes input tensors through unmodified. It is meant to be used for layer-stacking type merges where you have only one input model. Useful for frankenmerging.
 
+### [Model Stock](https://arxiv.org/abs/2403.19522)
+
+Uses some neat geometric properties of fine tuned models to compute good weights for linear interpolation. Requires at least three models, including a base model.
+
+Parameters:
+
+- `filter_wise`: if true, weight calculation will be per-row rather than per-tensor. Not recommended.
+
 # Citation
 
 We now have a [paper](https://arxiv.org/abs/2403.13257) you can cite for the MergeKit library:
@@ -175,3 +184,4 @@ We now have a [paper](https://arxiv.org/abs/2403.13257) you can cite for the Mer
   journal={arXiv preprint arXiv:2403.13257},
   year={2024}
 }
+```

--- a/mergekit/card.py
+++ b/mergekit/card.py
@@ -14,7 +14,7 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
 import os
-from typing import List, Optional, Sequence
+from typing import Generator, List, Optional
 
 import huggingface_hub
 import yaml
@@ -67,7 +67,7 @@ def is_hf(path: str) -> bool:
         return False
 
 
-def extract_hf_paths(models: List[ModelReference]) -> Sequence[str]:
+def extract_hf_paths(models: List[ModelReference]) -> Generator[str, None, None]:
     """
     Yields all valid Hugging Face paths from a list of ModelReference objects.
 
@@ -96,6 +96,7 @@ def method_md(merge_method: str) -> str:
         "task_arithmetic": "[task arithmetic](https://arxiv.org/abs/2212.04089)",
         "dare_ties": "[DARE](https://arxiv.org/abs/2311.03099) [TIES](https://arxiv.org/abs/2306.01708)",
         "dare_linear": "linear [DARE](https://arxiv.org/abs/2311.03099)",
+        "model_stock": "[Model Stock](https://arxiv.org/abs/2403.19522)",
     }
     return methods.get(merge_method, merge_method)
 

--- a/mergekit/io/tasks.py
+++ b/mergekit/io/tasks.py
@@ -2,7 +2,6 @@ import os
 from typing import Dict, Optional, Tuple
 
 import torch
-from torch._tensor import Tensor
 
 from mergekit.architecture import WeightInfo
 from mergekit.common import ImmutableMap, ModelReference, dtype_from_name
@@ -116,7 +115,7 @@ class GatherTensors(Task[Dict[ModelReference, torch.Tensor]]):
     def priority(self) -> int:
         return -10
 
-    def execute(self, **kwargs) -> Dict[ModelReference, Tensor]:
+    def execute(self, **kwargs) -> Dict[ModelReference, torch.Tensor]:
         key2model = {
             f"{str(model)}:{wi.name}": model for (model, wi) in self.weight_info.items()
         }

--- a/mergekit/io/tensor_writer.py
+++ b/mergekit/io/tensor_writer.py
@@ -117,7 +117,7 @@ class TensorWriter:
             json.dump(
                 {
                     "metadata": {
-                        "mergekit_version": "0.0.4.1",
+                        "mergekit_version": "0.0.4.2",
                         "total_size": self.total_size,
                     },
                     "weight_map": self.weight_map,

--- a/mergekit/merge_methods/__init__.py
+++ b/mergekit/merge_methods/__init__.py
@@ -20,6 +20,7 @@ from mergekit.merge_methods.generalized_task_arithmetic import (
     SparsificationMethod,
 )
 from mergekit.merge_methods.linear import LinearMerge
+from mergekit.merge_methods.model_stock import ModelStockMerge
 from mergekit.merge_methods.passthrough import PassthroughMerge
 from mergekit.merge_methods.slerp import SlerpMerge
 from mergekit.merge_methods.tokenizer_permute import TokenizerPermutationMerge
@@ -56,6 +57,8 @@ def get(method: str) -> MergeMethod:
             sparsification_method=SparsificationMethod.rescaled_random,
             default_normalize=False,
         )
+    elif method == "model_stock":
+        return ModelStockMerge()
     raise RuntimeError(f"Unimplemented merge method {method}")
 
 

--- a/mergekit/merge_methods/linear.py
+++ b/mergekit/merge_methods/linear.py
@@ -16,7 +16,6 @@
 from typing import Any, Dict, List
 
 import torch
-from torch._tensor import Tensor
 
 from mergekit.architecture import WeightInfo
 from mergekit.common import ImmutableMap, ModelReference, rectify_embed_sizes
@@ -37,7 +36,9 @@ class LinearMergeTask(Task[torch.Tensor]):
     def arguments(self) -> Dict[str, Task]:
         return {"tensors": self.gather_tensors}
 
-    def execute(self, tensors: Dict[ModelReference, torch.Tensor], **_kwargs) -> Tensor:
+    def execute(
+        self, tensors: Dict[ModelReference, torch.Tensor], **_kwargs
+    ) -> torch.Tensor:
         keys = list(tensors.keys())
 
         tensors = [tensors[key] for key in keys]

--- a/mergekit/merge_methods/model_stock.py
+++ b/mergekit/merge_methods/model_stock.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2024 Charles O. Goddard
+#
+# This software is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+
+from typing import Dict, Optional
+
+import torch
+
+from mergekit.architecture import WeightInfo
+from mergekit.common import ModelReference, rectify_embed_sizes
+from mergekit.graph import Task
+from mergekit.io.tasks import GatherTensors
+from mergekit.merge_methods.base import MergeMethod
+
+
+class ModelStockMergeTask(Task[torch.Tensor]):
+    gather_tensors: GatherTensors
+    base_model: ModelReference
+    parameter_name: str
+
+    def uses_accelerator(self) -> bool:
+        return True
+
+    def arguments(self) -> Dict[str, Task]:
+        return {"tensors": self.gather_tensors}
+
+    def execute(self, tensors: Dict[ModelReference, torch.Tensor]) -> torch.Tensor:
+        if len(tensors) == 1 and self.base_model in tensors:
+            return tensors[self.base_model]
+        if len(tensors) != 3:
+            raise ValueError(
+                "ModelStockMerge requires exactly 3 tensors (base plus two others)"
+            )
+
+        if self.base_model not in tensors:
+            raise ValueError("Base model tensor not found")
+        w_0 = tensors[self.base_model]
+        w_1, w_2 = [tensors[k] for k in tensors if k != self.base_model]
+
+        rectify_embed_sizes(self.parameter_name, [w_0, w_1, w_2])
+
+        w_1_offset = w_1 - w_0
+        w_2_offset = w_2 - w_0
+
+        norm_product = torch.norm(w_1_offset, dim=-1) * torch.norm(w_2_offset, dim=-1)
+        cos_theta = (
+            (w_1_offset * w_2_offset).sum(dim=-1, keepdim=True)
+            / norm_product.clamp(min=1e-6)
+        ).clamp(-1, 1)
+        cos_theta = cos_theta.unsqueeze(-1)
+
+        t = (2 * cos_theta) / (1 + cos_theta)
+
+        w_12 = (w_1 + w_2) / 2
+        return t * w_12 + (1 - t) * w_0
+
+
+class ModelStockMerge(MergeMethod):
+    def make_task(
+        self,
+        *,
+        output_weight: WeightInfo,
+        tensors: GatherTensors,
+        base_model: Optional[ModelReference],
+        **_kwargs,
+    ) -> Task:
+        return ModelStockMergeTask(
+            gather_tensors=tensors,
+            base_model=base_model,
+            parameter_name=output_weight.name,
+        )

--- a/mergekit/merge_methods/model_stock.py
+++ b/mergekit/merge_methods/model_stock.py
@@ -51,11 +51,10 @@ class ModelStockMergeTask(Task[torch.Tensor]):
 
         rectify_embed_sizes(self.parameter_name, [w_0] + ws)
 
-        is_vector = w_0.dim() == 1
         out_shape = w_0.shape
 
         if self.filter_wise:
-            if is_vector:
+            if w_0.dim() == 1:
                 # bias (or other single-vector) parameters should be treated as row vectors
                 w_0 = w_0.unsqueeze(0)
                 ws = [w.unsqueeze(0) for w in ws]

--- a/mergekit/merge_methods/passthrough.py
+++ b/mergekit/merge_methods/passthrough.py
@@ -16,7 +16,6 @@
 from typing import Any, Dict, List
 
 import torch
-from torch._tensor import Tensor
 
 from mergekit.common import ImmutableMap, ModelReference
 from mergekit.graph import Task
@@ -31,7 +30,7 @@ class PassthroughMergeTask(Task[torch.Tensor]):
     def arguments(self) -> Dict[str, Task]:
         return {"tensors": self.gather_tensors}
 
-    def execute(self, tensors: Dict[ModelReference, torch.Tensor]) -> Tensor:
+    def execute(self, tensors: Dict[ModelReference, torch.Tensor]) -> torch.Tensor:
         if len(tensors) != 1:
             raise RuntimeError("Passthrough merge expects exactly one tensor")
 

--- a/mergekit/merge_methods/slerp.py
+++ b/mergekit/merge_methods/slerp.py
@@ -17,7 +17,6 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import torch
-from torch._tensor import Tensor
 
 from mergekit.architecture import WeightInfo
 from mergekit.common import ImmutableMap, ModelReference, rectify_embed_sizes
@@ -38,7 +37,7 @@ class SlerpTask(Task[torch.Tensor]):
     def arguments(self) -> Dict[str, Task]:
         return {"tensors": self.gather_tensors}
 
-    def execute(self, tensors: Dict[ModelReference, torch.Tensor]) -> Tensor:
+    def execute(self, tensors: Dict[ModelReference, torch.Tensor]) -> torch.Tensor:
         if len(tensors) == 1:
             return list(tensors.values())[0]
         elif len(tensors) != 2:

--- a/mergekit/merge_methods/tokenizer_permute.py
+++ b/mergekit/merge_methods/tokenizer_permute.py
@@ -17,7 +17,6 @@ from typing import Any, Dict, List, Optional
 
 import torch
 from pydantic import BaseModel
-from torch._tensor import Tensor
 
 from mergekit.common import ImmutableMap, ModelReference
 from mergekit.graph import Task
@@ -43,7 +42,7 @@ class TokenizerPermutationMergeTask(Task[torch.Tensor]):
 
     def execute(
         self, tokenizer_info: TokenizerInfo, tensors: Dict[ModelReference, torch.Tensor]
-    ) -> Tensor:
+    ) -> torch.Tensor:
         if not tensors:
             return None
         if len(tensors) == 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "mergekit"
 description = "Tools for merging pre-trained large language models"
 readme = "README.md"
 license = { text = "LGPL-3.0-or-later" }
-version = "0.0.4.1"
+version = "0.0.4.2"
 authors = [{ name = "Charles Goddard", email = "chargoddard@gmail.com" }]
 dependencies = [
     "torch>=2.0.0",

--- a/tests/test_basic_merges.py
+++ b/tests/test_basic_merges.py
@@ -125,6 +125,12 @@ class TestBasicMerges:
         )
         run_and_check_merge(config)
 
+    def test_model_stock_merge(self, model_a, model_b, model_c):
+        config = self.two_model_config(
+            model_b, model_c, merge_method="model_stock", base_model=model_a
+        )
+        run_and_check_merge(config)
+
     def two_model_config(
         self,
         model_a,

--- a/tests/test_basic_merges.py
+++ b/tests/test_basic_merges.py
@@ -131,6 +131,16 @@ class TestBasicMerges:
         )
         run_and_check_merge(config)
 
+    def test_model_stock_filterwise_merge(self, model_a, model_b, model_c):
+        config = self.two_model_config(
+            model_b,
+            model_c,
+            merge_method="model_stock",
+            base_model=model_a,
+            params={"filter_wise": True},
+        )
+        run_and_check_merge(config)
+
     def two_model_config(
         self,
         model_a,


### PR DESCRIPTION
Adds an implementation of the approach described in [Model Stock: All we need is just a few fine-tuned models](https://arxiv.org/abs/2403.19522).

The `model_stock` merge method takes at least three models (one base model plus at least two fine tunes). No parameters are necessary. The result will be a linear combination of the base model and the average of the fine tunes, with the coefficient determined by some geometric wizardry.