### PR TITLE
Use numel() * element_size() instead of nbytes

### DIFF
--- a/mergekit/io/tensor_writer.py
+++ b/mergekit/io/tensor_writer.py
@@ -61,7 +61,7 @@ class TensorWriter:
             tensor = tensor.clone()
 
         self.current_shard[name] = tensor
-        self.total_size += tensor.nbytes
+        self.total_size += tensor.numel() * tensor.element_size()
         self.current_shard_size += tensor_size
 
     def flush_current_shard(self):


### PR DESCRIPTION
Fixes #232. `nbytes` is defined to be `numel() * element_size()`, so just do that instead to preserve compatibility with older pytorch versions.