### PR TITLE
Lora extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Mergekit allows extracting PEFT-compatible low-rank approximations of finetuned 
 ### Usage:
 
 ```sh
-mergekit-extract-lora extracted_peft_model_output_path --base-model=your_base_model --finetuned-model=finetuned_model_to_extract_lora_from [--no-lazy-unpickle] --rank=desired_rank
+mergekit-extract-lora finetuned_model_id_or_path base_model_id_or_path output_path [--no-lazy-unpickle] --rank=desired_rank
 ```
 
 # Citation

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Mergekit allows extracting PEFT-compatible low-rank approximations of finetuned 
 ### Usage:
 
 ```sh
-mergekit-extract-lora extracted_peft_model_output_path --base-model=your_base_model --finetuned-model=finetuned_model_to_extract_lora_from --rank=desired_rank
+mergekit-extract-lora extracted_peft_model_output_path --base-model=your_base_model --finetuned-model=finetuned_model_to_extract_lora_from [--no-lazy-unpickle] --rank=desired_rank
 ```
 
 # Citation

--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ Parameters: same as [TIES](#ties) for `dare_ties`, or [Linear](#linear) for `dar
 
 `passthrough` is a no-op that simply passes input tensors through unmodified. It is meant to be used for layer-stacking type merges where you have only one input model. Useful for frankenmerging.
 
+## LoRA extraction
+
+Mergekit allows extracting PEFT-compatible low-rank approximations of finetuned models.
+
+### Usage:
+
+```sh
+mergekit-extract-lora extracted_peft_model_output_path --base-model=your_base_model --finetuned-model=finetuned_model_to_extract_lora_from --rank=desired_rank
+```
+
 # Citation
 
 We now have a [paper](https://arxiv.org/abs/2403.13257) you can cite for the MergeKit library:

--- a/mergekit/architecture.py
+++ b/mergekit/architecture.py
@@ -275,6 +275,10 @@ class MixtralTensorNames(ArchitectureInfo, BaseModel):
         res = []
         for name in tensor_names:
             res.append(WeightInfo(name=name))
+        for weight_info in MISTRAL_INFO.layer_weights(index, config):
+            if ".mlp." in weight_info.name:
+                continue
+            res.append(weight_info)
         return res
 
     def sliceable(self) -> bool:

--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -8,7 +8,8 @@ import torch
 from peft.tuners.lora import QuantLinear
 from safetensors.torch import save_file
 from tqdm import tqdm
-from transformers import AutoConfig, AutoModelForCausalLM, PretrainedModel
+from transformers import AutoConfig, AutoModelForCausalLM
+from transformers.modeling_utils import PreTrainedModel
 
 from mergekit.common import ModelReference
 from mergekit.io import LazyTensorLoader
@@ -73,7 +74,7 @@ def decompose_delta_weight(
     return A, B
 
 
-def find_all_linear_names(model: PretrainedModel) -> List[str]:
+def find_all_linear_names(model: PreTrainedModel) -> List[str]:
     cls = (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt, torch.nn.Linear, QuantLinear)
 
     names = []

--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -109,7 +109,8 @@ def create_peft_config(base_model_name_or_path, rank, alpha, target_modules):
 @click.option("--base-model", type=str, help="Model ID or path to use as base model")
 @click.option("--finetuned-model", type=str, help="Model ID or path to use as PEFT extraction target model")
 @click.option("--rank", type=int, default=32, help="Rank for the low-rank decomposition")
-def main(out_path: str, base_model: str, finetuned_model: str, rank: int):
+@click.option("--device", type=str, default=None, help="PyTorch device to perform SVD computation on")
+def main(out_path: str, base_model: str, finetuned_model: str, rank: int, device: str):
     """
     Decomposes delta weights between a base model and a finetuned model and saves a PEFT model.
     """
@@ -133,7 +134,7 @@ def main(out_path: str, base_model: str, finetuned_model: str, rank: int):
         base_weight = base_loader.get_tensor(f"{layer_name}.weight")
         finetuned_weight = finetuned_loader.get_tensor(f"{layer_name}.weight")
         
-        lora_A, lora_B = decompose_delta_weight(finetuned_weight, base_weight, rank, device='cpu')
+        lora_A, lora_B = decompose_delta_weight(finetuned_weight, base_weight, rank, device=device)
         
         lora_weights[f"base_model.model.{layer_name}.lora_A.weight"] = lora_A.to('cpu').contiguous()
         lora_weights[f"base_model.model.{layer_name}.lora_B.weight"] = lora_B.to('cpu').contiguous()

--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -184,8 +184,8 @@ def reconstruct_invocation(args):
     help="PyTorch device to perform SVD computation on",
 )
 def main(
-    base_model: str,
     finetuned_model: str,
+    base_model: str,
     out_path: str,
     no_lazy_unpickle: bool,
     desired_rank: int,

--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -1,0 +1,156 @@
+import os
+import json
+import torch
+import click
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoConfig
+from mergekit.io import LazyTensorLoader
+from mergekit.common import ModelReference
+from mergekit.options import add_merge_options
+from safetensors.torch import save_file
+import bitsandbytes as bnb
+from transformers import AutoModelForCausalLM, AutoConfig
+from peft.tuners.lora import QuantLinear
+    
+def _low_rank_decomposition(weight, reduced_rank=16):
+    """
+    Decompose a 2D matrix into low-rank matrices A and B using SVD.a
+
+    :param weight: The matrix to decompose, of shape (H, W)
+    :param reduced_rank: The final rank of the decomposition
+    :return: A tuple of tensors (A, B)
+    """
+    if weight.dim() != 2:
+        raise ValueError(f"Only support 2D matrix, but your input has {weight.dim()} dimensions.")
+
+    # SVD Decomposition
+    U, S, Vh = torch.linalg.svd(weight, full_matrices=False)
+
+    # Truncated matrices
+    A = Vh[:reduced_rank, :]
+    B = U[:, :reduced_rank] @ torch.diag(S[:reduced_rank])
+
+    return A, B
+
+def decompose_delta_weight(new_weight, base_weight, reduced_rank, device=None):
+    if device is None:
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+    new_weight = new_weight.to(device)
+    base_weight = base_weight.to(device)
+
+    """
+    Decompose the delta weight into low-rank matrices A and B.
+
+    :param new_weight: The updated weight matrix after applying LoRA.
+    :param base_weight: The original weight matrix before LoRA.
+    :param reduced_rank: The rank for the low-rank decomposition.
+    :return: A tuple of tensors (A, B)
+    """
+    delta_weight = new_weight - base_weight   
+
+    max_rank = min(delta_weight.shape)
+    assert reduced_rank <= max_rank, f"The specified rank ({reduced_rank}) must be smaller than or equal to the rank of the weight matrices ({max_rank})"
+
+    A, B = _low_rank_decomposition(delta_weight, reduced_rank=reduced_rank)
+
+    return A, B
+
+def find_all_linear_names(model):
+    cls = (bnb.nn.Linear4bit, bnb.nn.Linear8bitLt, torch.nn.Linear, QuantLinear)
+
+    names = []
+    for name, module in model.named_modules():
+        if (
+            isinstance(module, cls)
+            or "Linear" in module.__class__.__name__
+            and module.__class__.__name__ not in ("LlamaLinearScalingRotaryEmbedding",)
+        ):
+            names.append(name)
+
+    return names
+
+def get_linear_module_names(model_id):
+    model = AutoModelForCausalLM.from_pretrained(model_id, state_dict={}, device_map="meta") #avoid loading weights as we won't need them
+    linear_module_names = find_all_linear_names(model)
+    
+    return linear_module_names
+
+
+def create_peft_config(base_model_name_or_path, rank, alpha, target_modules):
+    return {
+        "alpha_pattern": {},
+        "auto_mapping": None,
+        "base_model_name_or_path": base_model_name_or_path,
+        "bias": "none",
+        "fan_in_fan_out": False,
+        "inference_mode": True,
+        "init_lora_weights": True,
+        "layers_pattern": None,
+        "layers_to_transform": None,
+        "loftq_config": {},
+        "lora_alpha": alpha,
+        "lora_dropout": 0,
+        "megatron_config": None,
+        "megatron_core": "megatron.core",
+        "modules_to_save": None,
+        "peft_type": "LORA",
+        "r": rank,
+        "rank_pattern": {},
+        "revision": None,
+        "target_modules": target_modules,
+        "task_type": "CAUSAL_LM",
+        "use_rslora": False
+    }
+    
+
+@click.command("mergekit-extract-lora")
+@click.argument("out_path", type=click.Path())
+@click.option("--base-model", type=str, help="Model ID or path to use as base model")
+@click.option("--finetuned-model", type=str, help="Model ID or path to use as PEFT extraction target model")
+@click.option("--rank", type=int, default=32, help="Rank for the low-rank decomposition")
+def main(out_path: str, base_model: str, finetuned_model: str, rank: int):
+    """
+    Decomposes delta weights between a base model and a finetuned model and saves a PEFT model.
+    """
+    os.makedirs(out_path, exist_ok=True)
+
+    base_model_ref = ModelReference.parse(base_model)
+    finetuned_model_ref = ModelReference.parse(finetuned_model)
+
+    base_model_config = AutoConfig.from_pretrained(base_model_ref.model.path)
+
+    linear_module_names = get_linear_module_names(base_model_ref.model.path)
+    finetuned_model_linear_module_names = get_linear_module_names(finetuned_model_ref.model.path)
+    
+    assert set(linear_module_names) == set(finetuned_model_linear_module_names), "Model architecture mismatch"
+
+    base_loader = LazyTensorLoader(base_model_ref.tensor_index(), lazy_unpickle=True)
+    finetuned_loader = LazyTensorLoader(finetuned_model_ref.tensor_index(), lazy_unpickle=True)
+
+    lora_weights = {}
+    for layer_name in tqdm(linear_module_names):
+        base_weight = base_loader.get_tensor(f"{layer_name}.weight")
+        finetuned_weight = finetuned_loader.get_tensor(f"{layer_name}.weight")
+        
+        lora_A, lora_B = decompose_delta_weight(finetuned_weight, base_weight, rank, device='cpu')
+        
+        lora_weights[f"base_model.model.{layer_name}.lora_A.weight"] = lora_A.to('cpu').contiguous()
+        lora_weights[f"base_model.model.{layer_name}.lora_B.weight"] = lora_B.to('cpu').contiguous()
+        
+    lora_config = create_peft_config(
+            base_model_name_or_path = base_model_ref.model.path,
+            alpha=rank, # Setting the alpha to the reduced rank value (instead of alpha value used) seems to give better performance. Further testing would be needed to understand what is the optimal alpha value to use
+            rank=rank,
+            target_modules=list(set([module_name.split('.')[-1] for module_name in linear_module_names])),
+    )
+        
+    with open(os.path.join(out_path, 'adapter_config.json'), 'w') as f:
+        json.dump(lora_config, f, indent=2)
+
+    save_file(lora_weights, os.path.join(out_path, 'adapter_model.safetensors'))
+    
+    print(f"PEFT LoRA adapters saved to {out_path}")
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ mergekit-legacy = "mergekit.scripts.legacy:main"
 mergekit-layershuffle = "mergekit.scripts.layershuffle:main"
 bakllama = "mergekit.scripts.bakllama:main"
 mergekit-moe = "mergekit.scripts.mixtral_moe:main"
+mergekit-extract-lora = "mergekit.scripts.extract_lora:main"
 
 [tool.setuptools]
 packages = [


### PR DESCRIPTION
This PR adds support for extracting PEFT compatible LoRAs out of fine tune models as demonstrated in my [LoRD](https://github.com/thomasgauthier/LoRD/) repo.

Potential improvements:
  - Automatic model card creation (right now the script just outputs config and weights)
  - Better heuristics around choosing a proper alpha value. The current version uses alpha=rank as it seemed to give good result empirically but there might be some other trick we could use to find good alpha values (gradient based or otherwise)
  - Evals and metrics to assess how viable this technique is
  - Ability to use a custom rank for each weight tensor, some weight matrices might be contributing more to the task vectors and might benefit from higher ranks
    - Automating the search for good rank values seems like a promising area of research, [Fernando Neto](https://twitter.com/FernandoNetoAi) shared some interesting ideas with me for accomplishing this using Random Matrix Theory. See my comments below
