### PR TITLE
Generic Sparsification Rescaling

### DIFF
--- a/mergekit/merge_methods/__init__.py
+++ b/mergekit/merge_methods/__init__.py
@@ -38,30 +38,28 @@ def get(method: str) -> MergeMethod:
             consensus_method=None,
             sparsification_method=None,
             default_normalize=False,
+            default_rescale=False,
         )
     elif method == "ties":
         return GeneralizedTaskArithmeticMerge(
             consensus_method=ConsensusMethod.sum,
             sparsification_method=SparsificationMethod.magnitude,
             default_normalize=True,
-        )
-    elif method == "rescaled_ties":
-        return GeneralizedTaskArithmeticMerge(
-            consensus_method=ConsensusMethod.sum,
-            sparsification_method=SparsificationMethod.magnitude,
-            default_normalize=True,
+            default_rescale=False,
         )
     elif method == "dare_ties":
         return GeneralizedTaskArithmeticMerge(
             consensus_method=ConsensusMethod.sum,
-            sparsification_method=SparsificationMethod.rescaled_random,
+            sparsification_method=SparsificationMethod.random,
             default_normalize=False,
+            default_rescale=True,
         )
     elif method == "dare_linear":
         return GeneralizedTaskArithmeticMerge(
             consensus_method=None,
-            sparsification_method=SparsificationMethod.rescaled_random,
+            sparsification_method=SparsificationMethod.random,
             default_normalize=False,
+            default_rescale=True,
         )
     elif method == "model_stock":
         return ModelStockMerge()

--- a/mergekit/merge_methods/__init__.py
+++ b/mergekit/merge_methods/__init__.py
@@ -45,6 +45,12 @@ def get(method: str) -> MergeMethod:
             sparsification_method=SparsificationMethod.magnitude,
             default_normalize=True,
         )
+    elif method == "rescaled_ties":
+        return GeneralizedTaskArithmeticMerge(
+            consensus_method=ConsensusMethod.sum,
+            sparsification_method=SparsificationMethod.magnitude,
+            default_normalize=True,
+        )
     elif method == "dare_ties":
         return GeneralizedTaskArithmeticMerge(
             consensus_method=ConsensusMethod.sum,

--- a/mergekit/merge_methods/generalized_task_arithmetic.py
+++ b/mergekit/merge_methods/generalized_task_arithmetic.py
@@ -38,12 +38,16 @@ class GeneralizedTaskArithmeticMerge(MergeMethod, BaseModel, frozen=True):
     consensus_method: Optional[ConsensusMethod]
     sparsification_method: Optional[SparsificationMethod]
     default_normalize: bool
+    default_rescale: bool
 
     def parameters(self) -> List[ConfigParameterDef]:
         return [
             ConfigParameterDef(name="int8_mask", required=False, default_value=False),
             ConfigParameterDef(
                 name="normalize", required=False, default_value=self.default_normalize
+            ),
+            ConfigParameterDef(
+                name="rescale", required=False, default_value=self.default_rescale
             ),
         ]
 
@@ -68,6 +72,7 @@ class GeneralizedTaskArithmeticMerge(MergeMethod, BaseModel, frozen=True):
             tensor_parameters=tensor_parameters,
             int8_mask=parameters["int8_mask"],
             normalize=parameters["normalize"],
+            rescale=parameters["rescale"],
             out_tensor_name=output_weight.name,
         )
 
@@ -80,6 +85,7 @@ class GTATask(Task[torch.Tensor]):
     tensor_parameters: ImmutableMap[ModelReference, Any]
     int8_mask: bool
     normalize: bool
+    rescale: bool
 
     def uses_accelerator(self) -> bool:
         return True
@@ -109,6 +115,7 @@ class GTATask(Task[torch.Tensor]):
                     tv_info["delta"],
                     density=tv_info["density"],
                     method=self.method.sparsification_method,
+                    rescale=self.rescale,
                 )
 
         deltas = torch.stack([tv["delta"] for tv in tvs], dim=0)

--- a/mergekit/sparsify.py
+++ b/mergekit/sparsify.py
@@ -22,21 +22,21 @@ class SparsificationMethod(str, Enum):
     magnitude = "magnitude"
     random = "random"
 
-def rescaling(tensor: torch.Tensor, mask: torch.Tensor):
+
+def rescale_sum(tensor: torch.Tensor, mask: torch.Tensor):
     """Rescales the values to match the original tensor sum."""
     org_sum = tensor.abs().sum()
     new_sum = (tensor * mask).abs().sum()
-    
-    if(org_sum >= 1e-8):
-        tensor *= (org_sum / new_sum)
+
+    if org_sum >= 1e-8:
+        tensor *= org_sum / new_sum
     else:
         pass
 
     return tensor * mask
 
-def magnitude(
-    tensor: torch.Tensor, density: float, rescale: bool
-    ) -> torch.Tensor:
+
+def magnitude(tensor: torch.Tensor, density: float, rescale: bool) -> torch.Tensor:
     """Masks out the smallest values, retaining a proportion of `density`."""
     if density >= 1:
         return tensor
@@ -52,16 +52,14 @@ def magnitude(
     mask.view(-1)[topk.indices] = 1
 
     if rescale:
-        res = rescaling(tensor, mask)
+        res = rescale_sum(tensor, mask)
     else:
         res = tensor * mask
 
     return res
 
 
-def bernoulli(
-    tensor: torch.Tensor, density: float, rescale: bool
-) -> torch.Tensor:
+def bernoulli(tensor: torch.Tensor, density: float, rescale: bool) -> torch.Tensor:
     if density >= 1:
         return tensor
 
@@ -81,7 +79,10 @@ def bernoulli(
 
 
 def sparsify(
-    tensor: torch.Tensor, density: float, method: SparsificationMethod, rescale: bool
+    tensor: torch.Tensor,
+    density: float,
+    method: SparsificationMethod,
+    rescale: bool = False,
 ) -> torch.Tensor:
     if method == SparsificationMethod.magnitude:
         return magnitude(tensor, density=density, rescale=rescale)

--- a/mergekit/sparsify.py
+++ b/mergekit/sparsify.py
@@ -20,6 +20,7 @@ import torch
 
 class SparsificationMethod(str, Enum):
     magnitude = "magnitude"
+    rescaled_magnitude = "rescaled_magnitude"
     random = "random"
     rescaled_random = "rescaled_random"
 
@@ -83,6 +84,8 @@ def sparsify(
 ) -> torch.Tensor:
     if method == SparsificationMethod.magnitude:
         return magnitude(tensor, density=density)
+    if method == SparsificationMethod.rescaled_magnitude:
+        return magnitude(tensor, density=density, rescale=True)
     elif method == SparsificationMethod.random:
         return bernoulli(tensor, density=density, rescale=False)
     elif method == SparsificationMethod.rescaled_random:

--- a/tests/test_sparsify.py
+++ b/tests/test_sparsify.py
@@ -37,7 +37,10 @@ class TestBernoulli:
         avg_abs_sum = torch.zeros_like(ref_abs_sum)
         for _ in range(TestBernoulli.NUM_ITERATIONS):
             rescaled = sparsify(
-                sample_tensor, density=0.5, method=SparsificationMethod.rescaled_random
+                sample_tensor,
+                density=0.5,
+                method=SparsificationMethod.random,
+                rescale=True,
             )
             avg_abs_sum += rescaled.abs().sum()
         avg_abs_sum /= TestBernoulli.NUM_ITERATIONS
@@ -46,7 +49,10 @@ class TestBernoulli:
 
     def test_bernoulli_without_rescale(self, sample_tensor):
         result = sparsify(
-            sample_tensor, density=0.5, method=SparsificationMethod.random
+            sample_tensor,
+            density=0.5,
+            method=SparsificationMethod.random,
+            rescale=False,
         )
         assert 0 < torch.count_nonzero(result) <= sample_tensor.view(-1).shape[0]
 
@@ -55,5 +61,6 @@ class TestBernoulli:
             sparsify(
                 tensor=sample_tensor.to(dtype=dt).cpu(),
                 density=0.5,
-                method=SparsificationMethod.rescaled_random,
+                method=SparsificationMethod.random,
+                rescale=True,
             )


### PR DESCRIPTION
According to the [DARE paper](https://arxiv.org/pdf/2311.03099.pdf), rescaling allows for the sparsified tensor to approximate the original tensor. In the paper, this statement is made:
> We have also tried to combine MP with the rescale operation but got worse results than using MP separately. This is because MP removes parameters with smaller magnitudes and retains certain parameters with the largest magnitudes. Simply rescaling the remaining ones would destroy the original embeddings and result in unpredictable performance.
They claim that rescaling MP results in worse performance, but according to their theory, it should work. I believe that that they may have used the same rescaling operation as in the DARE method. However, the simple rescaling method, 1/density, used for DARE only works due to dropping making the sum of the weights equal to the sum times the density. For sparsification methods that do not use random dropping, the necessary rescaling changes based on the distribution of value in the weights.

In is due to this that I have implemented a generic rescaling method. This also cleans up some of the code (No more rescaled random). To keep compatibility, TIES still has no rescaling by default, but by adding `rescale: true` to the parameters, you can enable it. Below is a test using it:

<table>
<tr>
 <td>Model
 <td>MMLU
 <td>ARC
 <td>Winogrande
<tr>
 <td>TIES (rescaled)
 <td>51.08%
 <td>50.85%
 <td>75.53%
<tr>
 <td>DARE TIES
 <td>48.08%
 <td>45.39%
 <td>76.56%
</table>

This is not meant as proof that this method works. I am making this change mostly to help make future development of sparsification methods easier, since this rescaling algorithm works regardless of the sparsification method. (Technically DARE could even be switched to use it, but finding the necessary multiplier is more computationally expensive than the simpler implementation that is only available with dropping.)