### PR TITLE
Add Sample Sparsification Method

### DIFF
--- a/mergekit/sparsify.py
+++ b/mergekit/sparsify.py
@@ -23,6 +23,8 @@ class SparsificationMethod(str, Enum):
     random = "random"
     rescaled_random = "rescaled_random"
 
+def sample():
+    pass
 
 def magnitude(tensor: torch.Tensor, density: float) -> torch.Tensor:
     """Masks out the smallest values, retaining a proportion of `density`."""


### PR DESCRIPTION
This is a new sparsification method that I have been thinking about. The trimming and dropping methods resemble the Top-P and Typical-P methods used in sampling LLMs. However, by far the most popular sampler is the temperature sampler.

This sparsification method samples the tensor itself to create its mask. This method is FAR more computationally expensive, but it, theoritically, should outperform other methods.