### PR TITLE
Switch to argsort over TopK

### DIFF
--- a/mergekit/sparsify.py
+++ b/mergekit/sparsify.py
@@ -36,8 +36,8 @@ def magnitude(tensor: torch.Tensor, density: float) -> torch.Tensor:
     w = tensor.abs().view(-1)
     if w.device.type == "cpu":
         w = w.float()
-    topk = torch.topk(w, k=k, largest=True)
-    mask.view(-1)[topk.indices] = 1
+    topk = torch.argsort(w, descending=True)[:k]
+    mask.view(-1)[topk] = 1
 
     return tensor * mask
 


### PR DESCRIPTION
Using argsort over TopK seems to use less memory and run faster.

I found `0.6873465579992626` for argsort and `0.7168450749959447` for TopK.

This should be expected behavior for a flattened tensor.