### PR TITLE
Update README.md w/ correct git clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features:
 ## Installation
 
 ```sh
-git clone https://github.com/cg123/mergekit.git
+git clone https://github.com/arcee-ai/mergekit.git
 cd mergekit
 
 pip install -e .  # install the package and make scripts available


### PR DESCRIPTION
Looks like the git clone url is pointed to the old github org