### PR TITLE
`mergekit-evolve` QoL tweaks

### DIFF
--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -28,6 +28,7 @@ import ray.util.scheduling_strategies
 import torch
 import transformers
 from transformers.utils import is_flash_attn_2_available
+from transformers import AutoModelForCausalLM
 
 try:
     import vllm
@@ -40,7 +41,7 @@ from mergekit.config import MergeConfiguration
 from mergekit.evo.config import EvolMergeConfiguration
 from mergekit.evo.genome import ModelGenome
 from mergekit.evo.helpers import _eval_model, evaluate_model, merge_model
-from mergekit.evo.monkeypatch import NoInit, monkeypatch_lmeval_shuffle
+from mergekit.evo.monkeypatch import NoInit, monkeypatch_lmeval_shuffle, monkeypatch_lmeval_vllm
 from mergekit.graph import Executor
 from mergekit.io.tasks import LoaderCache, ReturnTensor
 from mergekit.merge import _model_out_config
@@ -73,6 +74,7 @@ class MergeActorBase:
             monkeypatch_lmeval_shuffle()
 
         # monkeypatch_tqdm()
+        monkeypatch_lmeval_vllm()
 
 
 @ray.remote(num_cpus=1, num_gpus=1.0)

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -27,6 +27,7 @@ import ray.util.queue
 import ray.util.scheduling_strategies
 import torch
 import transformers
+from transformers.utils import is_flash_attn_2_available
 
 try:
     import vllm
@@ -169,7 +170,9 @@ class InMemoryMergeEvaluator(MergeActorBase):
                 transformers.AutoModelForCausalLM.from_config(
                     cfg_out,
                     trust_remote_code=self.merge_options.trust_remote_code,
-                    attn_implementation="flash_attention_2",
+                    attn_implementation="flash_attention_2"
+                    if is_flash_attn_2_available()
+                    else "default",
                     torch_dtype=torch.bfloat16,
                 )
                 .bfloat16()

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -165,15 +165,18 @@ class InMemoryMergeEvaluator(MergeActorBase):
             if not different:
                 return
 
+        model_kwargs = {
+            "trust_remote_code": self.merge_options.trust_remote_code,
+            "torch_dtype": torch.bfloat16,
+        }
+        if is_flash_attn_2_available():
+            model_kwargs["attn_implementation"] = "flash_attention_2"
+
         with NoInit():
             inner_model = (
                 transformers.AutoModelForCausalLM.from_config(
                     cfg_out,
-                    trust_remote_code=self.merge_options.trust_remote_code,
-                    attn_implementation="flash_attention_2"
-                    if is_flash_attn_2_available()
-                    else "default",
-                    torch_dtype=torch.bfloat16,
+                    **model_kwargs,
                 )
                 .bfloat16()
                 .cuda()

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -214,11 +214,14 @@ class InMemoryMergeEvaluator(MergeActorBase):
                     max_model_len = 8192
                     logging.warn(f"Clipping sequence length to {max_model_len}")
 
+                mem_util = (
+                    0.7 if self.merge_options.cuda else 0.9
+                )  # reduce memory usage if we're also using cuda for the merge
                 self.model = lm_eval.models.vllm_causallms.VLLM(
                     pretrained=tempdir,
                     batch_size=self.batch_size or "auto",
                     max_model_len=max_model_len,
-                    gpu_memory_utilization=0.7,  # can't do 0.9 because the merge will OOM
+                    gpu_memory_utilization=mem_util,
                     dtype="bfloat16",
                     device="cuda",
                     trust_remote_code=self.merge_options.trust_remote_code,

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -285,6 +285,7 @@ class InMemoryMergeEvaluator(MergeActorBase):
             num_fewshot=self.config.num_fewshot,
             limit=self.config.limit,
             task_manager=self.task_manager,
+            batch_size=self.batch_size,
         )
 
     def evaluate_genotype(

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -28,7 +28,6 @@ import ray.util.scheduling_strategies
 import torch
 import transformers
 from transformers.utils import is_flash_attn_2_available
-from transformers import AutoModelForCausalLM
 
 try:
     import vllm
@@ -41,7 +40,11 @@ from mergekit.config import MergeConfiguration
 from mergekit.evo.config import EvolMergeConfiguration
 from mergekit.evo.genome import ModelGenome
 from mergekit.evo.helpers import _eval_model, evaluate_model, merge_model
-from mergekit.evo.monkeypatch import NoInit, monkeypatch_lmeval_shuffle, monkeypatch_lmeval_vllm
+from mergekit.evo.monkeypatch import (
+    NoInit,
+    monkeypatch_lmeval_shuffle,
+    monkeypatch_lmeval_vllm,
+)
 from mergekit.graph import Executor
 from mergekit.io.tasks import LoaderCache, ReturnTensor
 from mergekit.merge import _model_out_config

--- a/mergekit/evo/helpers.py
+++ b/mergekit/evo/helpers.py
@@ -27,9 +27,11 @@ import ray
 import ray.util.queue
 import ray.util.scheduling_strategies
 import torch
+import transformers
 
 from mergekit.evo.config import TaskConfiguration
 from mergekit.evo.genome import ModelGenome
+from mergekit.evo.monkeypatch import monkeypatch_lmeval_vllm
 from mergekit.merge import run_merge
 from mergekit.options import MergeOptions
 
@@ -68,6 +70,7 @@ def evaluate_model(
     task_manager: Optional[lm_eval.tasks.TaskManager] = None,
 ) -> float:
     # monkeypatch_tqdm()
+    monkeypatch_lmeval_vllm()
     try:
         model_args = {
             "pretrained": merged_path,

--- a/mergekit/evo/helpers.py
+++ b/mergekit/evo/helpers.py
@@ -27,7 +27,6 @@ import ray
 import ray.util.queue
 import ray.util.scheduling_strategies
 import torch
-import transformers
 
 from mergekit.evo.config import TaskConfiguration
 from mergekit.evo.genome import ModelGenome

--- a/mergekit/evo/monkeypatch.py
+++ b/mergekit/evo/monkeypatch.py
@@ -100,6 +100,15 @@ def monkeypatch_tqdm(lm_eval: bool = True, mergekit: bool = True):
         mergekit.tokenizer.tqdm = fake_module
 
 
+def monkeypatch_lmeval_vllm():
+    # HACK: fix crash on some tasks due to unset AUTO_MODEL_CLASS for vLLM
+    import lm_eval.models.vllm_causallms
+
+    lm_eval.models.vllm_causallms.VLLM.AUTO_MODEL_CLASS = (
+        transformers.AutoModelForCausalLM
+    )
+
+
 class NoInit:
     def __enter__(self):
         def noop(*args, **kwargs):

--- a/mergekit/evo/strategy.py
+++ b/mergekit/evo/strategy.py
@@ -89,6 +89,7 @@ class ActorPoolEvaluationStrategy(EvaluationStrategyBase):
                     self.merge_options,
                     model_storage_path=self.model_storage_path,
                     vllm=vllm,
+                    batch_size=self.batch_size,
                     task_manager=self.task_manager,
                 )
                 for _ in range(self.num_gpus)

--- a/mergekit/scripts/evolve.py
+++ b/mergekit/scripts/evolve.py
@@ -351,6 +351,7 @@ def _reshard_model(
         revision=merged.model.revision,
         trust_remote_code=trust_remote_code,
         torch_dtype=torch.bfloat16,
+        cache_dir=os.path.join(storage_path, "transformers_cache"),
     )
     model_hf.save_pretrained(
         out_path, safe_serialization=True, out_shard_size=1_000_000_000_000

--- a/mergekit/scripts/evolve.py
+++ b/mergekit/scripts/evolve.py
@@ -317,9 +317,9 @@ def main(
     print(f"Best cost: {xbest_cost:.4f}")
     print()
 
-    # save the best merge configuration, using original (unsharded) model references
-    genome_unsharded = ModelGenome(config.genome, trust_remote_code=trust_remote_code)
-    best_config = genome_unsharded.genotype_merge_config(xbest)
+    # save the best merge configuration using original model references
+    genome_pretty = ModelGenome(config.genome, trust_remote_code=trust_remote_code)
+    best_config = genome_pretty.genotype_merge_config(xbest)
     print("Best merge configuration:")
     print(best_config.to_yaml())
 

--- a/mergekit/scripts/evolve.py
+++ b/mergekit/scripts/evolve.py
@@ -21,6 +21,7 @@ import click
 import cma
 import numpy as np
 import pandas
+import ray
 import torch
 import tqdm
 import transformers
@@ -311,7 +312,7 @@ def main(
         )
         xbest_cost = es.result.fbest
     except KeyboardInterrupt:
-        pass
+        ray.shutdown()
 
     print("!!! OPTIMIZATION COMPLETE !!!")
     print(f"Best cost: {xbest_cost:.4f}")

--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -9,7 +9,7 @@ import torch
 from peft.tuners.lora import QuantLinear
 from safetensors.torch import save_file
 from tqdm import tqdm
-from transformers import AutoConfig, AutoModelForCausalLM
+from transformers import AutoModelForCausalLM
 from transformers.modeling_utils import PreTrainedModel
 
 from mergekit.card import generate_card_lora
@@ -215,8 +215,6 @@ def main(
 
     base_model_ref = ModelReference.parse(base_model)
     finetuned_model_ref = ModelReference.parse(finetuned_model)
-
-    base_model_config = AutoConfig.from_pretrained(base_model_ref.model.path)
 
     linear_module_names = get_linear_module_names(base_model_ref.model.path)
     finetuned_model_linear_module_names = get_linear_module_names(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["black~=24.2.0", "isort~=5.13.2", "pre-commit~=3.6.2"]
 test = ["pytest~=8.0.1"]
-evolve = ["ray", "cma", "lm_eval", "flash-attn", "wandb"]
+evolve = ["ray", "cma", "lm_eval", "wandb"]
 vllm = ["vllm==0.3.2", "lm_eval[vllm]"]
 
 [project.urls]


### PR DESCRIPTION
A few quality of life tweaks for `mergekit-evolve`:
1. Make flash attention optional
2. Write out the final merge instead of just the config (`--no-save-final-model` to disable)
3. Add option to not reshard input models (`--no-reshard`) for lower disk use at cost of merge speed