### PR TITLE
Add out_dtype option

### DIFF
--- a/mergekit/config.py
+++ b/mergekit/config.py
@@ -89,6 +89,7 @@ class MergeConfiguration(BaseModel):
     base_model: Optional[ModelReference] = None
     dtype: Optional[str] = None
     tokenizer_source: Optional[str] = None
+    out_dtype: Optional[str] = None
 
     def referenced_models(self) -> List[ModelReference]:
         models = set()

--- a/mergekit/io/tasks.py
+++ b/mergekit/io/tasks.py
@@ -209,6 +209,7 @@ class BuildStateDict(Task[Dict[str, torch.Tensor]]):
 class ReturnTensor(Task[torch.Tensor]):
     weight_info: WeightInfo
     tensor_task: Task[torch.Tensor]
+    dtype: Optional[str] = None
 
     def arguments(self) -> Dict[str, Task]:
         return {"tensor": self.tensor_task}
@@ -220,4 +221,6 @@ class ReturnTensor(Task[torch.Tensor]):
         return self.tensor_task.group_label()
 
     def execute(self, tensor: torch.Tensor) -> torch.Tensor:
+        if self.dtype and (dtype := dtype_from_name(self.dtype)) != tensor.dtype:
+            tensor = tensor.to(dtype=dtype)
         return tensor

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -260,7 +260,7 @@ class MergePlanner:
                     writer_task=writer_task,
                     clone=self.options.clone_tensors,
                     optional=weight.optional,
-                    dtype=weight.force_dtype,
+                    dtype=weight.force_dtype or self.config.out_dtype,
                 )
             )
         finalize = FinalizeModel(
@@ -275,7 +275,14 @@ class MergePlanner:
     def plan_in_memory(self) -> List[ReturnTensor]:
         """Plan the merge to be performed in memory."""
         self._plan()
-        return [ReturnTensor(weight_info=w, tensor_task=t) for w, t in self._tensors]
+        return [
+            ReturnTensor(
+                weight_info=w,
+                tensor_task=t,
+                dtype=w.force_dtype or self.config.out_dtype,
+            )
+            for w, t in self._tensors
+        ]
 
     def _plan(self):
         self.normalize_config()


### PR DESCRIPTION
Allows specifying a dtype to store the final model in independent of the dtype used for intermediate calculations.

For example, to do all calculations in fp32 then write the final model in bf16:
```yml
dtype: float32
out_dtype: bfloat16
```