### PR TITLE
Set Gemma2 lm_head optional instead of aliasing to embed_tokens

### DIFF
--- a/mergekit/_data/architectures/gemma2.json
+++ b/mergekit/_data/architectures/gemma2.json
@@ -54,9 +54,7 @@
         {
             "name": "lm_head.weight",
             "is_embed": true,
-            "aliases": [
-                "model.embed_tokens.weight"
-            ]
+            "optional": true
         }
     ]
 }


### PR DESCRIPTION
Resolves #385.