### PR TITLE
Pad embeds to multiple

### DIFF
--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -179,12 +179,15 @@ class MergePlanner:
         tensor_input_task = gather_tensors
         if self._tokenizer_task and weight.is_embed:
             token_cfg = {}
+            pad_to_multiple = None
             if cfg_reader.config.tokenizer:
                 token_cfg = cfg_reader.config.tokenizer.tokens
+                pad_to_multiple = cfg_reader.config.tokenizer.pad_to_multiple_of
             tensor_input_task = PermutedEmbeddings(
                 gather_tensors=gather_tensors,
                 tokenizer_task=self._tokenizer_task,
                 tokens=token_cfg,
+                pad_to_multiple_of=pad_to_multiple,
                 base_model=base_model,
             )
 

--- a/mergekit/scripts/tokensurgeon.py
+++ b/mergekit/scripts/tokensurgeon.py
@@ -190,7 +190,7 @@ def main(
     tokenizer.save_pretrained(out_path)
     cfg_out = arch_info.config
     try:
-        cfg_out.vocab_size = tokenizer.vocab_size
+        cfg_out.vocab_size = new_embed.shape[0]
     except AttributeError:
         LOG.error(
             "Could not set vocab size in config.json - you may need to update it manually."

--- a/mergekit/tokenizer/config.py
+++ b/mergekit/tokenizer/config.py
@@ -49,3 +49,4 @@ class TokenEmbeddingConfig(BaseModel, frozen=True):
 class TokenizerConfig(BaseModel, frozen=True):
     source: Union[ModelReference, Literal["union"], Literal["base"]] = "union"
     tokens: Optional[Dict[str, TokenEmbeddingConfig]] = None
+    pad_to_multiple_of: Optional[int] = None


### PR DESCRIPTION
Add the ability to pad the output embeddings to a multiple of a user-defined factor when merging tokenizers.

Config syntax example:
```yaml
merge_method: linear
models:
  - model: model_a
  - model: model_b
parameters:
  weight: 0.5
tokenizer:
  source: union
  pad_to_multiple_of: 64
```