### PR TITLE
extract_lora : support tied embeddings

### DIFF
--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -215,7 +215,7 @@ def get_model_tensor(loader: LazyTensorLoader, name: str) -> torch.Tensor:
     except KeyError as e:
         # Some models like Llama 3.2 1B have tied embedding and output layers, so we need to retry
         if name == "lm_head.weight":
-            return loader.get_tensor("embed_tokens.weight")
+            return loader.get_tensor("model.embed_tokens.weight")
 
 def extract_lora(
     module_details: List[Tuple[str, str]],


### PR DESCRIPTION
Fix https://github.com/arcee-ai/mergekit/issues/447

Some small models like Llama 3.2 1B, 3B or Qwen 1.5B have tied embeddings, meaning token embeddings tensor and output tensor (lm_head) are the same.

Demo:

```sh
 mergekit-extract-lora \
  ngxson/MiniThinky-v2-1B-Llama-3.2 \
  meta-llama/Llama-3.2-1B-Instruct \
  lora_out --rank=16
```