### PR TITLE
Add SCE merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Parameters: same as [Linear](#linear), plus:
 
 ### [SCE](https://arxiv.org/abs/2408.07990)
 
-Building upon TIES, SCE introduces adaptive matrix-level merging weights based on parameter variances. SCE first selects the top-k% elements from each parameter matrix that exhibit high variance across all delta parameters. Following this selection, SCE calculates matrix-level merging weights based on the sum of squares of elements in the delta parameters. Finally, it erases minority elements, a step similar to the sign election process in TIES.
+SCE introduces adaptive matrix-level merging weights based on parameter variances. SCE first selects the top-k% elements from each parameter matrix that exhibit high variance across all delta parameters. Following this selection, SCE calculates matrix-level merging weights based on the sum of squares of elements in the delta parameters. Finally, it erases minority elements, a step similar to the sign election process in TIES.
 
 Parameters:
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ A quick overview of the currently supported merge methods:
 | NuSLERP                                                                                          | `nuslerp`            | ❌          | ✅              |
 | [DELLA](https://arxiv.org/abs/2406.11617)                                                        | `della`              | ✅          | ✅              |
 | [DELLA](https://arxiv.org/abs/2406.11617) [Task Arithmetic](https://arxiv.org/abs/2212.04089)    | `della_linear`       | ✅          | ✅              |
+| [SCE](https://arxiv.org/abs/2408.07990)                                                          | `sce`                | ✅          | ✅              |
 
 ### Linear
 
@@ -335,6 +336,14 @@ Parameters: same as [Linear](#linear), plus:
 - `density` - fraction of weights in differences from the base model to retain
 - `epsilon` - maximum change in drop probability based on magnitude. Drop probabilities assigned will range from `density - epsilon` to `density + epsilon`. (When selecting values for `density` and `epsilon`, ensure that the range of probabilities falls within 0 to 1)
 - `lambda` - scaling factor for the final merged delta parameters before merging with the base parameters.
+
+### [SCE](https://arxiv.org/abs/2408.07990)
+
+Building upon TIES, SCE introduces adaptive matrix-level merging weights based on parameter variances. SCE first selects the top-k% elements from each parameter matrix that exhibit high variance across all delta parameters. Following this selection, SCE calculates matrix-level merging weights based on the sum of squares of elements in the delta parameters. Finally, it erases minority elements, a step similar to the sign election process in TIES.
+
+Parameters:
+
+- `select_topk` - fraction of elements with the highest variance in the delta parameters to retain.
 
 ## LoRA extraction
 

--- a/mergekit/card.py
+++ b/mergekit/card.py
@@ -121,6 +121,7 @@ def method_md(merge_method: str) -> str:
         "della": "[DELLA](https://arxiv.org/abs/2406.11617)",
         "della_linear": "linear [DELLA](https://arxiv.org/abs/2406.11617)",
         "nuslerp": "NuSLERP",
+        "sce": "[SCE](https://arxiv.org/abs/2408.07990)",
     }
     return methods.get(merge_method, merge_method)
 

--- a/mergekit/merge_methods/__init__.py
+++ b/mergekit/merge_methods/__init__.py
@@ -23,6 +23,7 @@ from mergekit.merge_methods.linear import LinearMerge
 from mergekit.merge_methods.model_stock import ModelStockMerge
 from mergekit.merge_methods.nuslerp import NuSlerpMerge
 from mergekit.merge_methods.passthrough import PassthroughMerge
+from mergekit.merge_methods.sce import SCEMerge
 from mergekit.merge_methods.slerp import SlerpMerge
 from mergekit.merge_methods.tokenizer_permute import TokenizerPermutationMerge
 
@@ -112,6 +113,9 @@ def get(method: str) -> MergeMethod:
             default_normalize=True,
             default_rescale=False,
         )
+
+    elif method == "sce":
+        return SCEMerge()
     raise RuntimeError(f"Unimplemented merge method {method}")
 
 
@@ -119,6 +123,7 @@ __all__ = [
     "MergeMethod",
     "get",
     "LinearMerge",
+    "SCEMerge",
     "SlerpMerge",
     "PassthroughMerge",
     "GeneralizedTaskArithmeticMerge",

--- a/mergekit/merge_methods/sce.py
+++ b/mergekit/merge_methods/sce.py
@@ -1,0 +1,202 @@
+# Copyright (C) 2024 Charles O. Goddard
+#
+# This software is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+from pydantic import BaseModel
+
+from mergekit.architecture import WeightInfo
+from mergekit.common import ImmutableMap, ModelReference
+from mergekit.graph import Task
+from mergekit.merge_methods.base import (
+    ConfigParameterDef,
+    MergeMethod,
+    MergeTensorInput,
+)
+
+
+class SCEMerge(MergeMethod, BaseModel, frozen=True):
+    def parameters(self) -> List[ConfigParameterDef]:
+        return [
+            ConfigParameterDef(name="int8_mask", required=False, default_value=False),
+            ConfigParameterDef(name="select_topk", required=False, default_value=1.0),
+        ]
+
+    def make_task(
+        self,
+        output_weight: WeightInfo,
+        tensors: MergeTensorInput,
+        base_model: Optional[ModelReference],
+        parameters: ImmutableMap[str, Any],
+        **_kwargs,
+    ) -> Task:
+        return SCETask(
+            tensors=tensors,
+            base_model=base_model,
+            int8_mask=parameters["int8_mask"],
+            select_topk=parameters["select_topk"],
+            weight_info=output_weight,
+        )
+
+
+class SCETask(Task[torch.Tensor]):
+    tensors: MergeTensorInput
+    base_model: ModelReference
+    weight_info: WeightInfo
+    int8_mask: bool
+    select_topk: float
+
+    def uses_accelerator(self) -> bool:
+        return True
+
+    def arguments(self) -> Dict[str, Task]:
+        return {"tensors": self.tensors}
+
+    def execute(
+        self,
+        tensors: Dict[ModelReference, torch.Tensor],
+        **_kwargs,
+    ) -> torch.Tensor:
+        # collect task vectors
+        tvs, base = get_task_vectors(self.weight_info, self.base_model, tensors)
+        if not tvs:
+            return base
+
+        deltas = torch.stack([tv["delta"] for tv in tvs], dim=0)
+        mask_dtype = torch.int8 if self.int8_mask else base.dtype
+
+        # Select the top τ% elements with high variance
+        if self.select_topk < 1:
+            mask = get_sce_mask(deltas, self.select_topk, mask_dtype)
+            mask_expanded = mask.unsqueeze(0).expand_as(deltas)
+            deltas = deltas * mask_expanded
+
+        # Calculate matrix level merging coefficient
+        weights = get_sce_weight(deltas)
+        weights = torch.tensor(weights, dtype=deltas.dtype, device=deltas.device)
+        while len(deltas.shape) > len(weights.shape):
+            weights.unsqueeze_(-1)
+
+        # Erase elements with minority directions
+        erase_mask = get_erase_mask(
+            deltas,
+            mask_dtype=mask_dtype,
+        )
+        erased_weights = weights * erase_mask
+        mixed_delta = (deltas * erased_weights).sum(dim=0)
+
+        # Normalize
+        divisor = (erased_weights).sum(dim=0)
+        divisor[divisor == 0] = 1
+        mixed_delta /= divisor
+
+        return (base + mixed_delta).to(base.dtype)
+
+
+def get_task_vectors(
+    weight_info: WeightInfo,
+    base_model: ModelReference,
+    tensors: ImmutableMap[ModelReference, torch.Tensor],
+) -> Tuple[List[Dict[str, Any]], torch.Tensor]:
+    keys = list(tensors.keys())
+    base = tensors[base_model]
+
+    parameter_name = weight_info.name
+
+    res = []
+    for model in keys:
+        if model == base_model:
+            continue
+
+        x = tensors[model].to(base.dtype)
+        if x.shape != base.shape:
+            if weight_info.is_embed:
+                x = x[: base.shape[0], : base.shape[1]]
+                logging.warning(f"Using submatrix of {model}:{parameter_name}")
+            else:
+                logging.warning(
+                    f"skipping {model}:{parameter_name} due to size mismatch"
+                )
+                continue
+
+        delta = x - base
+        del x
+        del tensors[model]
+
+        d = {}
+        d["model"] = model
+        d["delta"] = delta
+        res.append(d)
+    return res, base
+
+
+def get_erase_mask(
+    delta: torch.Tensor,
+    mask_dtype: Optional[torch.dtype] = None,
+):
+    """Returns a mask determining which delta vectors should be merged
+    into the final model.
+    """
+    if mask_dtype is None:
+        mask_dtype = delta.dtype
+
+    sign = delta.sign().to(mask_dtype)
+
+    sign_weight = delta.sum(dim=0)
+    majority_sign = (sign_weight >= 0).to(mask_dtype) * 2 - 1
+    del sign_weight
+
+    return sign == majority_sign
+
+
+def get_sce_mask(
+    deltas: torch.Tensor,
+    density: float,
+    mask_dtype: Optional[torch.dtype] = None,
+):
+    if mask_dtype is None:
+        mask_dtype = deltas.dtype
+    # Calculate variance along the first dimension
+    variance = torch.var(deltas, dim=0, unbiased=False)
+    # Count non-zero positions in variance
+    non_zero_positions_count = torch.count_nonzero(variance)
+    # Calculate the number of top elements to select
+    k = int(abs(density) * non_zero_positions_count)
+    mask = torch.zeros_like(variance, dtype=mask_dtype)
+    if k == 0:
+        return mask
+    assert k > 0, "not gonna zero out the whole tensor buddy"
+
+    # Get the indices of the top k elements with the highest absolute variance
+    topk_indices = torch.topk(variance.abs().view(-1), k=k, largest=True).indices
+
+    mask.view(-1)[topk_indices] = 1
+    return mask
+
+
+def get_sce_weight(deltas):
+    # Calculate the squared sum of each delta and normalize by the number of elements
+    weights = [torch.sum(delta**2).item() / delta.numel() for delta in deltas]
+
+    # Normalize the weights
+    sum_weights = sum(weights)
+    if sum_weights == 0:
+        weights = [1.0 / len(weights)] * len(weights)
+    else:
+        weights = [w / sum_weights for w in weights]
+
+    return weights


### PR DESCRIPTION
This pull request introduces a novel method for large language model (LLM) merging, leveraging the power of [SCE](https://arxiv.org/abs/2408.07990). SCE incorporates adaptive matrix-level merging weights derived from parameter variance analysis.

**Key Features of SCE:**

- **Selective Attention:** SCE **s**elects high-variance elements across all delta parameters within each parameter matrix. This focuses the merging process on the most informative parts of the models.
- **Adaptive Weighting:**  SCE **c**alculates matrix-level merging weights based on the sum of squares of elements in the delta parameters. This ensures that models with more significant parameter variations contribute more to the fused model.
- **Sparsification:** Similar sign election process in TIES, SCE **e**rases minority elements.


**Improved LLM Performance through SCE:**

We have demonstrated the effectiveness of SCE in our [FuseChat (https://arxiv.org/abs/2408.07990)](https://arxiv.org/abs/2408.07990) paper. Recent days, we  further employ SCE to integrate multiple open-source o1-like LLMs into a unified model. [FuseO1](https://huggingface.co/blog/Wanfq/fuseo1-preview) involves two primary merging strategies:

- **Long-Long Reasoning Merging**: This approach involves model fusion across LLMs that utilize long-CoT reasoning, with the goal of enhancing long-CoT reasoning capabilities. The resulted [FuseAI/FuseO1-DeepSeekR1-QwQ-SkyT1-32B-Preview](https://huggingface.co/FuseAI/FuseO1-DeepSeekR1-QwQ-SkyT1-32B-Preview) achieves a Pass@1 accuracy of **74.0 on AIME24**,  demonstrating significant performance improvements compared to the OpenAI o1-preview (44.6) and OpenAI o1-mini (63.4), even approaching OpenAI o1 (79.2).
- **Long-Short Reasoning Merging**: This approach involves model fusion between long-CoT and short-CoT LLMs, aiming to improve reasoning capabilities in both long and short reasoning processes. The resulted [FuseAI/FuseO1-DeepSeekR1-Qwen2.5-Instruct-32B-Preview](https://huggingface.co/FuseAI/FuseO1-DeepSeekR1-Qwen2.5-Instruct-32B-Preview) is capable of utilizing both long and short reasoning processes and demonstrates relatively strong performance in long reasoning tasks.

We have run the pre-commit hook locally to standardize the formatting, please let us know if you require any modifications or clarifications for this pull request.