### PR TITLE
Apply chat template in `mergekit-evolve`

### DIFF
--- a/mergekit/evo/config.py
+++ b/mergekit/evo/config.py
@@ -28,6 +28,8 @@ class EvolMergeConfiguration(BaseModel, frozen=True):
     num_fewshot: Optional[int] = None
     shuffle: bool = False
     random_init: bool = False
+    apply_chat_template: bool = True
+    fewshot_as_multiturn: bool = True
 
 
 NAUGHTY_PREFIXES = [

--- a/mergekit/evo/strategy.py
+++ b/mergekit/evo/strategy.py
@@ -165,6 +165,8 @@ class BufferedRayEvaluationStrategyActor:
                             vllm=self.vllm,
                             batch_size=self.batch_size,
                             task_manager=self.task_manager,
+                            apply_chat_template=self.config.apply_chat_template,
+                            fewshot_as_multiturn=self.config.fewshot_as_multiturn,
                             **kwargs,
                         )
                     ] = future_result
@@ -265,6 +267,8 @@ def evaluate_genotype_serial(
             vllm=vllm,
             batch_size=batch_size,
             task_manager=task_manager,
+            apply_chat_template=config.apply_chat_template,
+            fewshot_as_multiturn=config.fewshot_as_multiturn,
             **kwargs,
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 dev = ["black~=24.10.0", "isort~=5.13.2", "pre-commit~=4.1.0"]
 test = ["pytest~=8.3.4"]
 evolve = ["ray", "cma", "lm_eval", "wandb"]
-vllm = ["vllm==0.3.2", "lm_eval[vllm]"]
+vllm = ["vllm==0.7.2", "lm_eval[vllm]"]
 
 [project.urls]
 repository = "https://github.com/cg123/mergekit"


### PR DESCRIPTION
Minor update to allow passing `apply_chat_template` and `fewshot_as_multiturn` when running `mergekit-evolve`.