### PR TITLE
Fix type error in `extract_lora.py` : SVD only supports `float32`

### DIFF
--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -227,7 +227,11 @@ class TaskVectorDecompositionTask(Task[Tuple[torch.Tensor, torch.Tensor]]):
     def execute(self, task_vector: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         if self.transpose:
             task_vector = task_vector.T
+        orig_dtype = task_vector.dtype
+        # convert to float32 for SVD
+        task_vector = task_vector.to(torch.float32)
         u, s, vh = torch.linalg.svd(task_vector, full_matrices=False)
+        u, s, vh = u.to(orig_dtype), s.to(orig_dtype), vh.to(orig_dtype)
         rank = min(self.max_rank, s.shape[0])
         if self.sv_epsilon > 0:
             rank = min((s > self.sv_epsilon).sum().item(), rank)

--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -227,11 +227,10 @@ class TaskVectorDecompositionTask(Task[Tuple[torch.Tensor, torch.Tensor]]):
     def execute(self, task_vector: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         if self.transpose:
             task_vector = task_vector.T
-        orig_dtype = task_vector.dtype
-        # convert to float32 for SVD
-        task_vector = task_vector.to(torch.float32)
-        u, s, vh = torch.linalg.svd(task_vector, full_matrices=False)
-        u, s, vh = u.to(orig_dtype), s.to(orig_dtype), vh.to(orig_dtype)
+        # convert task_vector to float32 before SVD, then convert results back to original data type
+        original_dtype = task_vector.dtype
+        u, s, vh = torch.linalg.svd(task_vector.to(torch.float32), full_matrices=False)
+        u, s, vh = u.to(original_dtype), s.to(original_dtype), vh.to(original_dtype)
         rank = min(self.max_rank, s.shape[0])
         if self.sv_epsilon > 0:
             rank = min((s > self.sv_epsilon).sum().item(), rank)


### PR DESCRIPTION
Running `extract_lora.py` on any model that does not use `float32` as its default tensor type currently results in a `RuntimeError`. This is a significant limitation, as many recent models default to `bfloat16` or `float16` (half precision). The error arises from the use of the `torch.linalg.svd` API, which only supports `torch.float32`. This pull request (PR) addresses the issue by converting tensors to `float32` (full precision) before executing `torch.linalg.svd`, and then converting them back to their original data type afterwards.