### PR TITLE
(fix) upgrade immutables to v0.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "safetensors~=0.5.2",
     "accelerate~=1.3.0",
     "pydantic~=2.10.6",
-    "immutables==0.20",
+    "immutables==0.21",
     "transformers>=4.45.2",
     "tokenizers>=0.20.1",
     "huggingface_hub",


### PR DESCRIPTION
fixes #516
the _PyLong_Format error during a pip install of mergekit
