### PR TITLE
Fix Llama4ForConditionalGeneration vision tower template.

### DIFF
--- a/mergekit/_data/architectures/llama4.json
+++ b/mergekit/_data/architectures/llama4.json
@@ -175,28 +175,28 @@
                             "name": "model.layers.${layer_index}.post_attention_layernorm.bias"
                         },
                         {
-                            "name": "model.layers.${layer_index}.attention.k_proj.weight"
+                            "name": "model.layers.${layer_index}.self_attn.k_proj.weight"
                         },
                         {
-                            "name": "model.layers.${layer_index}.attention.k_proj.bias"
+                            "name": "model.layers.${layer_index}.self_attn.k_proj.bias"
                         },
                         {
-                            "name": "model.layers.${layer_index}.attention.o_proj.weight"
+                            "name": "model.layers.${layer_index}.self_attn.o_proj.weight"
                         },
                         {
-                            "name": "model.layers.${layer_index}.attention.o_proj.bias"
+                            "name": "model.layers.${layer_index}.self_attn.o_proj.bias"
                         },
                         {
-                            "name": "model.layers.${layer_index}.attention.q_proj.weight"
+                            "name": "model.layers.${layer_index}.self_attn.q_proj.weight"
                         },
                         {
-                            "name": "model.layers.${layer_index}.attention.q_proj.bias"
+                            "name": "model.layers.${layer_index}.self_attn.q_proj.bias"
                         },
                         {
-                            "name": "model.layers.${layer_index}.attention.v_proj.weight"
+                            "name": "model.layers.${layer_index}.self_attn.v_proj.weight"
                         },
                         {
-                            "name": "model.layers.${layer_index}.attention.v_proj.bias"
+                            "name": "model.layers.${layer_index}.self_attn.v_proj.bias"
                         }
                     ]
                 },


### PR DESCRIPTION
Fix merging Llama 4 by fixing the naming scheme for the weights and biases of the vision tower.
The huggingface safetensors use 'model.layers.${layer_index}.self_attn' while the template specifies 'model.layers.${layer_index}.attention'. This causes an error because mergekit cannot find the misnamed layers when merging.