### PR TITLE
Properly propagate transformers_cache option

### DIFF
--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -39,7 +39,7 @@ def set_config_value(config: PretrainedConfig, key: str, value: Any):
     for idx, part in enumerate(parts[:-1]):
         if not hasattr(obj, part):
             raise RuntimeError(
-                f"Config {config} has no attribute {'.'.join(parts[:idx+1])}"
+                f"Config {config} has no attribute {'.'.join(parts[: idx + 1])}"
             )
         obj = getattr(obj, part)
     setattr(obj, parts[-1], value)
@@ -52,7 +52,7 @@ def get_config_value(config: PretrainedConfig, key: str) -> Any:
     for idx, part in enumerate(parts):
         if not hasattr(obj, part):
             raise RuntimeError(
-                f"Config {config} has no attribute {'.'.join(parts[:idx+1])}"
+                f"Config {config} has no attribute {'.'.join(parts[: idx + 1])}"
             )
         obj = getattr(obj, part)
     return obj
@@ -149,8 +149,13 @@ class ModelReference(BaseModel, frozen=True):
             res.architectures = [self.override_architecture]
         return res
 
-    def local_path(self, cache_dir: Optional[str] = None) -> str:
-        assert self.lora is None
+    def local_path(
+        self, cache_dir: Optional[str] = None, ignore_lora: bool = False
+    ) -> str:
+        if not ignore_lora:
+            assert (
+                self.lora is None
+            ), "LoRA not merged - use .merged() to get a local path"
 
         path = self.model.path
         if not os.path.exists(path):

--- a/mergekit/io/tasks.py
+++ b/mergekit/io/tasks.py
@@ -64,7 +64,7 @@ def _normalized_shard_name(path: str) -> int:
     name = name.lower().replace("pytorch_model", "model")
     if m := shard_name_re.search(name):
         frac = int(m.group(1)) / int(m.group(2))
-        name = f"model-{int(frac*100):03d}pct"
+        name = f"model-{int(frac * 100):03d}pct"
     return name
 
 

--- a/mergekit/io/tensor_writer.py
+++ b/mergekit/io/tensor_writer.py
@@ -65,10 +65,10 @@ class TensorWriter:
         if not self.current_shard:
             return
 
-        logger.info(f"Writing shard #{self.shards_written+1} to disk")
+        logger.info(f"Writing shard #{self.shards_written + 1} to disk")
 
         prefix, extension = self._get_name_components()
-        shard_name = f"{prefix}-{self.shards_written+1}.{extension}"
+        shard_name = f"{prefix}-{self.shards_written + 1}.{extension}"
 
         for key in self.current_shard:
             self.weight_map[key] = shard_name
@@ -95,8 +95,8 @@ class TensorWriter:
             total_shards = self.shards_written
             name_remap = {}
             for idx in range(total_shards):
-                name_remap[f"{prefix}-{idx+1}.{extension}"] = (
-                    f"{prefix}-{idx+1:05d}-of-{total_shards:05d}.{extension}"
+                name_remap[f"{prefix}-{idx + 1}.{extension}"] = (
+                    f"{prefix}-{idx + 1:05d}-of-{total_shards:05d}.{extension}"
                 )
 
             if total_shards < 2:

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -121,9 +121,7 @@ def run_merge(
     else:
         if options.copy_tokenizer:
             try:
-                _copy_tokenizer(
-                    merge_config, out_path, options=options
-                )
+                _copy_tokenizer(merge_config, out_path, options=options)
             except Exception as e:
                 logger.error(
                     "Failed to copy tokenizer. The merge was still successful, just copy it from somewhere else.",
@@ -207,7 +205,9 @@ def _copy_tagalong_files(
     options: MergeOptions,
 ):
     donor_model = merge_config.base_model or (merge_config.referenced_models()[0])
-    donor_local_path = donor_model.local_path(cache_dir=options.transformers_cache)
+    donor_local_path = donor_model.local_path(
+        cache_dir=options.transformers_cache, ignore_lora=True
+    )
 
     for file_name in files:
         fp = os.path.join(donor_local_path, file_name)
@@ -225,7 +225,9 @@ def _copy_tokenizer(
     merge_config: MergeConfiguration, out_path: str, options: MergeOptions
 ):
     donor_model = merge_config.base_model or (merge_config.referenced_models()[0])
-    donor_local_path = donor_model.local_path(cache_dir=options.transformers_cache)
+    donor_local_path = donor_model.local_path(
+        cache_dir=options.transformers_cache, ignore_lora=True
+    )
 
     if (
         (not merge_config.chat_template)

--- a/mergekit/merge_methods/easy_define.py
+++ b/mergekit/merge_methods/easy_define.py
@@ -167,7 +167,7 @@ def __merge_method(
 
     tt_fields["execute"] = _execute
 
-    tt_name = f"{name.title().replace(' ','')}MergeTask"
+    tt_name = f"{name.title().replace(' ', '')}MergeTask"
     tt_cls = pydantic.create_model(tt_name, __base__=Task[torch.Tensor], **tt_fields)
 
     mm_fields = {}
@@ -220,7 +220,7 @@ def __merge_method(
 
     mm_fields["parameters"] = _parameters
 
-    mm_name = f"{name.title().replace(' ','')}MergeMethod"
+    mm_name = f"{name.title().replace(' ', '')}MergeMethod"
     mm_cls = type(mm_name, (MergeMethod,), mm_fields)
     REGISTERED_MERGE_METHODS[name] = mm_cls()
     return func

--- a/mergekit/tokenizer/build.py
+++ b/mergekit/tokenizer/build.py
@@ -257,7 +257,7 @@ def build_tokenizer(
             orig_idx = model_vocab[tok]
             if orig_idx >= vocab_size:
                 logger.warning(
-                    f"{model} token {repr(tok)} has index {orig_idx}>{vocab_size-1} (padding?)"
+                    f"{model} token {repr(tok)} has index {orig_idx}>{vocab_size - 1} (padding?)"
                 )
                 continue
 


### PR DESCRIPTION
Fixes a bug where specifying `--transformers-cache` in some situations lead to downloading source models multiple times.