### PR TITLE
extend mergekit to make it work on xpu

### DIFF
--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -383,17 +383,42 @@ def get_auto_cls(arch_name: str) -> AutoClassProtocol:
     return auto_cls
 
 
-def get_torch_accelerator_module():
-    return (
-        getattr(torch, torch.accelerator.current_accelerator().type)
-        if hasattr(torch, "accelerator")
-        else torch.cuda
-    )
+def get_torch_accelerator_module(accelerator_name: Optional[str] = None):
+    if accelerator_name is not None:
+        accelerator_type = torch.device(accelerator_name).type
+        return getattr(torch, accelerator_type)
+    else:
+        return (
+            getattr(torch, torch.accelerator.current_accelerator().type)
+            if hasattr(torch, "accelerator")
+            else torch.cuda
+        )
 
 
-def get_torch_accelerator_type():
-    return (
-        torch.accelerator.current_accelerator().type
-        if hasattr(torch, "accelerator")
-        else "cuda"
-    )
+def get_torch_accelerator_count(accelerator_name: Optional[str] = None):
+    torch_accelerator_module = torch.cuda
+    if accelerator_name is not None:
+        accelerator = torch.device(accelerator_name)
+        # if user passes the device index in `acclerator_name`, then 1
+        if accelerator.index != None:
+            return 1
+        accelerator_type = accelerator.type
+        torch_accelerator_module = getattr(torch, accelerator_type)
+    else:
+        torch_accelerator_module = (
+            getattr(torch, torch.accelerator.current_accelerator().type)
+            if hasattr(torch, "accelerator")
+            else torch.cuda
+        )
+    return torch_accelerator_module.device_count()
+
+
+def get_torch_accelerator_type(accelerator_name: Optional[str] = None):
+    if accelerator_name is not None:
+        return torch.device(accelerator_name).type
+    else:
+        return (
+            torch.accelerator.current_accelerator().type
+            if hasattr(torch, "accelerator")
+            else "cuda"
+        )

--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -399,7 +399,7 @@ def get_torch_accelerator_count(accelerator_name: Optional[str] = None):
     torch_accelerator_module = torch.cuda
     if accelerator_name is not None:
         accelerator = torch.device(accelerator_name)
-        # if user passes the device index in `acclerator_name`, then 1
+        # if user passes the device index in `accelerator_name`, then 1
         if accelerator.index != None:
             return 1
         torch_accelerator_module = getattr(torch, accelerator.type)

--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -402,8 +402,7 @@ def get_torch_accelerator_count(accelerator_name: Optional[str] = None):
         # if user passes the device index in `acclerator_name`, then 1
         if accelerator.index != None:
             return 1
-        accelerator_type = accelerator.type
-        torch_accelerator_module = getattr(torch, accelerator_type)
+        torch_accelerator_module = getattr(torch, accelerator.type)
     else:
         torch_accelerator_module = (
             getattr(torch, torch.accelerator.current_accelerator().type)

--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -381,3 +381,19 @@ def get_auto_cls(arch_name: str) -> AutoClassProtocol:
             )
         auto_cls = transformers.AutoModelForCausalLM
     return auto_cls
+
+
+def get_torch_accelerator_module():
+    return (
+        getattr(torch, torch.accelerator.current_accelerator().type)
+        if hasattr(torch, "accelerator")
+        else torch.cuda
+    )
+
+
+def get_torch_accelerator_type():
+    return (
+        torch.accelerator.current_accelerator().type
+        if hasattr(torch, "accelerator")
+        else "cuda"
+    )

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -90,7 +90,7 @@ class OnDiskMergeEvaluator(MergeActorBase):
         genotype: torch.Tensor,
     ) -> dict:
         gc.collect()
-        torch_acclerator_module=getattr(torch, self.merge_options.device, torch.cuda)
+        torch_acclerator_module = getattr(torch, self.merge_options.device, torch.cuda)
         torch_acclerator_module.empty_cache()
         LOG.info("Merging model")
         merged_path = merge_model(
@@ -295,8 +295,16 @@ class InMemoryMergeEvaluator(MergeActorBase):
 
         executor = Executor(
             tasks,
-            math_device=self.merge_options.device if self.merge_options.device in ["cuda", "xpu"] else "cpu",
-            storage_device=self.merge_options.device if self.merge_options.device in ["cuda", "xpu"] else "cpu",
+            math_device=(
+                self.merge_options.device
+                if self.merge_options.device in ["cuda", "xpu"]
+                else "cpu"
+            ),
+            storage_device=(
+                self.merge_options.device
+                if self.merge_options.device in ["cuda", "xpu"]
+                else "cpu"
+            ),
         )
         for tensor_task, value in executor.run(quiet=True):
             assert isinstance(tensor_task, ReturnTensor)

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -90,8 +90,8 @@ class OnDiskMergeEvaluator(MergeActorBase):
         genotype: torch.Tensor,
     ) -> dict:
         gc.collect()
-        torch_acclerator_module = getattr(torch, self.merge_options.device, torch.cuda)
-        torch_acclerator_module.empty_cache()
+        torch_accelerator_module = getattr(torch, self.merge_options.device, torch.cuda)
+        torch_accelerator_module.empty_cache()
         LOG.info("Merging model")
         merged_path = merge_model(
             genotype, self.genome, self.model_storage_path, self.merge_options
@@ -227,8 +227,9 @@ class InMemoryMergeEvaluator(MergeActorBase):
                     max_model_len = 8192
                     LOG.warning(f"Clipping sequence length to {max_model_len}")
 
+                accelerator_type = torch.device(self.merge_options.device).type
                 mem_util = (
-                    0.7 if self.merge_options.device in ["cuda", "xpu"] else 0.9
+                    0.7 if accelerator_type in ["cuda", "xpu"] else 0.9
                 )  # reduce memory usage if we're also using accelerator for the merge
                 self.model = lm_eval.models.vllm_causallms.VLLM(
                     pretrained=tempdir,

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 from mergekit.architecture import arch_info_for_config
-from mergekit.commom import get_torch_accelerator_module, get_torch_accelerator_type
+from mergekit.common import get_torch_accelerator_module, get_torch_accelerator_type
 from mergekit.config import MergeConfiguration
 from mergekit.evo.config import EvolMergeConfiguration
 from mergekit.evo.genome import InvalidGenotypeError, ModelGenome

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -90,7 +90,8 @@ class OnDiskMergeEvaluator(MergeActorBase):
         genotype: torch.Tensor,
     ) -> dict:
         gc.collect()
-        empty_cache()
+        torch_acclerator_module=getattr(torch, self.merge_options.device, torch.cuda)
+        torch_acclerator_module.empty_cache()
         LOG.info("Merging model")
         merged_path = merge_model(
             genotype, self.genome, self.model_storage_path, self.merge_options

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -294,16 +294,17 @@ class InMemoryMergeEvaluator(MergeActorBase):
             ".up_proj.": (".gate_up_proj.", 1),
         }
 
+        accelerator_type = torch.device(self.merge_options.device).type
         executor = Executor(
             tasks,
             math_device=(
                 self.merge_options.device
-                if self.merge_options.device in ["cuda", "xpu"]
+                if accelerator_type in ["cuda", "xpu"]
                 else "cpu"
             ),
             storage_device=(
                 self.merge_options.device
-                if self.merge_options.device in ["cuda", "xpu"]
+                if accelerator_type in ["cuda", "xpu"]
                 else "cpu"
             ),
         )

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -26,6 +26,7 @@ except ImportError:
 
 
 from mergekit.architecture import arch_info_for_config
+from mergekit.commom import get_torch_accelerator_module
 from mergekit.config import MergeConfiguration
 from mergekit.evo.config import EvolMergeConfiguration
 from mergekit.evo.genome import InvalidGenotypeError, ModelGenome
@@ -90,7 +91,9 @@ class OnDiskMergeEvaluator(MergeActorBase):
         genotype: torch.Tensor,
     ) -> dict:
         gc.collect()
-        torch_accelerator_module = getattr(torch, self.merge_options.device, torch.cuda)
+        torch_accelerator_module = get_torch_accelerator_module(
+            self.merge_options.device
+        )
         torch_accelerator_module.empty_cache()
         LOG.info("Merging model")
         merged_path = merge_model(

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 from mergekit.architecture import arch_info_for_config
-from mergekit.commom import get_torch_accelerator_module
+from mergekit.commom import get_torch_accelerator_module, get_torch_accelerator_type
 from mergekit.config import MergeConfiguration
 from mergekit.evo.config import EvolMergeConfiguration
 from mergekit.evo.genome import InvalidGenotypeError, ModelGenome
@@ -230,7 +230,7 @@ class InMemoryMergeEvaluator(MergeActorBase):
                     max_model_len = 8192
                     LOG.warning(f"Clipping sequence length to {max_model_len}")
 
-                accelerator_type = torch.device(self.merge_options.device).type
+                accelerator_type = get_torch_accelerator_type(self.merge_options.device)
                 mem_util = (
                     0.7 if accelerator_type in ["cuda", "xpu"] else 0.9
                 )  # reduce memory usage if we're also using accelerator for the merge
@@ -297,7 +297,7 @@ class InMemoryMergeEvaluator(MergeActorBase):
             ".up_proj.": (".gate_up_proj.", 1),
         }
 
-        accelerator_type = torch.device(self.merge_options.device).type
+        accelerator_type = get_torch_accelerator_type(self.merge_options.device)
         executor = Executor(
             tasks,
             math_device=(

--- a/mergekit/evo/strategy.py
+++ b/mergekit/evo/strategy.py
@@ -15,7 +15,7 @@ import ray.util.scheduling_strategies
 import torch
 import transformers
 
-from mergekit.commom import get_torch_accelerator_count
+from mergekit.common import get_torch_accelerator_count
 from mergekit.evo.actors import InMemoryMergeEvaluator, OnDiskMergeEvaluator
 from mergekit.evo.config import EvolMergeConfiguration
 from mergekit.evo.genome import ModelGenome

--- a/mergekit/evo/strategy.py
+++ b/mergekit/evo/strategy.py
@@ -37,7 +37,9 @@ class EvaluationStrategyBase(ABC):
         self.config = config
         self.genome = genome
         self.merge_options = merge_options
-        self.num_gpus = num_gpus or getattr(torch, self.merge_options.device).device_count()
+        self.num_gpus = (
+            num_gpus or getattr(torch, self.merge_options.device).device_count()
+        )
         self.batch_size = batch_size
         self.task_manager = lm_eval.tasks.TaskManager(include_path=task_search_path)
         self.model_storage_path = model_storage_path
@@ -118,7 +120,9 @@ class BufferedRayEvaluationStrategyActor:
         self.genome = genome
         self.merge_options = merge_options
         self.vllm = vllm
-        self.num_gpus = num_gpus or getattr(torch, self.merge_options.device).device_count()
+        self.num_gpus = (
+            num_gpus or getattr(torch, self.merge_options.device).device_count()
+        )
         self.input_queue = []
         self.batch_size = batch_size
         self.task_manager = task_manager

--- a/mergekit/evo/strategy.py
+++ b/mergekit/evo/strategy.py
@@ -15,6 +15,7 @@ import ray.util.scheduling_strategies
 import torch
 import transformers
 
+from mergekit.commom import get_torch_accelerator_count
 from mergekit.evo.actors import InMemoryMergeEvaluator, OnDiskMergeEvaluator
 from mergekit.evo.config import EvolMergeConfiguration
 from mergekit.evo.genome import ModelGenome
@@ -37,8 +38,8 @@ class EvaluationStrategyBase(ABC):
         self.config = config
         self.genome = genome
         self.merge_options = merge_options
-        self.num_gpus = (
-            num_gpus or getattr(torch, self.merge_options.device).device_count()
+        self.num_gpus = num_gpus or get_torch_accelerator_count(
+            self.merge_options.device
         )
         self.batch_size = batch_size
         self.task_manager = lm_eval.tasks.TaskManager(include_path=task_search_path)
@@ -120,8 +121,8 @@ class BufferedRayEvaluationStrategyActor:
         self.genome = genome
         self.merge_options = merge_options
         self.vllm = vllm
-        self.num_gpus = (
-            num_gpus or getattr(torch, self.merge_options.device).device_count()
+        self.num_gpus = num_gpus or get_torch_accelerator_count(
+            self.merge_options.device
         )
         self.input_queue = []
         self.batch_size = batch_size

--- a/mergekit/evo/strategy.py
+++ b/mergekit/evo/strategy.py
@@ -37,7 +37,7 @@ class EvaluationStrategyBase(ABC):
         self.config = config
         self.genome = genome
         self.merge_options = merge_options
-        self.num_gpus = num_gpus or torch.cuda.device_count()
+        self.num_gpus = num_gpus or getattr(torch, self.merge_options.device).device_count()
         self.batch_size = batch_size
         self.task_manager = lm_eval.tasks.TaskManager(include_path=task_search_path)
         self.model_storage_path = model_storage_path
@@ -118,7 +118,7 @@ class BufferedRayEvaluationStrategyActor:
         self.genome = genome
         self.merge_options = merge_options
         self.vllm = vllm
-        self.num_gpus = num_gpus or torch.cuda.device_count()
+        self.num_gpus = num_gpus or getattr(torch, self.merge_options.device).device_count()
         self.input_queue = []
         self.batch_size = batch_size
         self.task_manager = task_manager

--- a/mergekit/graph.py
+++ b/mergekit/graph.py
@@ -529,7 +529,7 @@ class Executor:
         self, value: Any, device: torch.device, non_blocking: Optional[bool] = None
     ) -> Any:
         if non_blocking is None:
-            non_blocking = device.type == "cuda"
+            non_blocking = device.type in ["cuda", "xpu"]
         if isinstance(value, torch.Tensor):
             if value.device == device:
                 return value

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -77,8 +77,8 @@ def run_merge(
     else:
         exec = Executor(
             targets=targets,
-            math_device="cuda" if options.cuda else "cpu",
-            storage_device="cuda" if options.low_cpu_memory else "cpu",
+            math_device=options.device,
+            storage_device=options.device if options.low_cpu_memory else "cpu",
         )
 
     tokenizer = None

--- a/mergekit/multigpu_executor.py
+++ b/mergekit/multigpu_executor.py
@@ -21,6 +21,7 @@ import networkx as nx
 import torch
 import tqdm
 
+from .common import get_torch_accelerator_module, get_torch_accelerator_type
 from .graph import (
     Executor,
     Task,
@@ -75,12 +76,8 @@ class MultiGPUExecutor:
         self.results: Dict[TaskHandle, Any] = {}
         self.storage_device = storage_device
 
-        self.accelerator_type = (
-            getattr(torch, torch.acclerator.current_accelerator().type)
-            if hasattr(torch, "accelerator")
-            else "cuda"
-        )
-        torch_accelerator_module = getattr(torch, self.accelerator_type)
+        self.accelerator_type = get_torch_accelerator_type()
+        torch_accelerator_module = get_torch_accelerator_module()
         if num_gpus is None:
             num_gpus = torch_accelerator_module.device_count()
         LOG.info(f"Using {num_gpus} {accelerator_type} for parallel execution")

--- a/mergekit/multigpu_executor.py
+++ b/mergekit/multigpu_executor.py
@@ -83,7 +83,7 @@ class MultiGPUExecutor:
         self.accelerator_type = get_torch_accelerator_type()
         if num_gpus is None:
             num_gpus = get_torch_accelerator_count()
-        LOG.info(f"Using {num_gpus} {accelerator_type} for parallel execution")
+        LOG.info(f"Using {num_gpus} {self.accelerator_type} for parallel execution")
 
         self.universe = TaskUniverse(targets)
         self.targets = set([self.universe.get_handle(t) for t in targets])

--- a/mergekit/multigpu_executor.py
+++ b/mergekit/multigpu_executor.py
@@ -75,9 +75,11 @@ class MultiGPUExecutor:
         self.results: Dict[TaskHandle, Any] = {}
         self.storage_device = storage_device
 
+        self.accelerator_type = getattr(torch, torch.acclerator.current_accelerator().type) if hasattr(torch, "accelerator") else "cuda"
+        torch_accelerator_module = getattr(torch, self.accelerator_type)
         if num_gpus is None:
-            num_gpus = torch.cuda.device_count()
-        LOG.info(f"Using {num_gpus} GPUs for parallel execution")
+            num_gpus = torch_accelerator_module.device_count()
+        LOG.info(f"Using {num_gpus} {accelerator_type} for parallel execution")
 
         self.universe = TaskUniverse(targets)
         self.targets = set([self.universe.get_handle(t) for t in targets])
@@ -309,12 +311,12 @@ class MultiGPUExecutor:
                 continue
             # don't need to sort, inner executor will handle
             island_tasks = [TaskHandle(self.universe, idx) for idx in island]
-            # assign to GPU with fewest tasks (load balancing)
+            # assign to accelerator with fewest tasks (load balancing)
             device_idx = min(
                 range(num_gpus),
-                key=lambda i: len(assignments.get(torch.device(f"cuda:{i}"), [])),
+                key=lambda i: len(assignments.get(torch.device(f"{self.accelerator_type}:{i}"), [])),
             )
-            device = torch.device(f"cuda:{device_idx}")
+            device = torch.device(f"{self.accelerator_type}:{device_idx}")
             assignments[device] = assignments.get(device, []) + island_tasks
         return assignments
 
@@ -339,9 +341,10 @@ class MultiGPUExecutor:
             quiet: Whether to suppress progress bar output
         """
         LOG.debug(f"Device {device} starting")
+        torch_accelerator_module = getattr(torch, self.accelerator_type)
         with torch.device(device):
-            stream = torch.cuda.Stream(device=device)
-            with torch.cuda.stream(stream):
+            stream = torch.Stream(device=device) if self.accelerator_type == "xpu" else torch.cuda.Stream(device=device)
+            with stream if self.accelerator_type == "xpu" else torch.cuda.stream(stream):
                 exec = Executor(
                     targets=task_list,
                     math_device=device,
@@ -358,5 +361,5 @@ class MultiGPUExecutor:
                     ):
                         result = None
                     self.task_completion_queue.put((task_handle._index, result))
-        torch.cuda.synchronize(device=device)
+        torch_accelerator_module.synchronize(device=device)
         LOG.debug(f"Device {device} done")

--- a/mergekit/multigpu_executor.py
+++ b/mergekit/multigpu_executor.py
@@ -21,7 +21,11 @@ import networkx as nx
 import torch
 import tqdm
 
-from .common import get_torch_accelerator_module, get_torch_accelerator_type
+from .common import (
+    get_torch_accelerator_count,
+    get_torch_accelerator_module,
+    get_torch_accelerator_type,
+)
 from .graph import (
     Executor,
     Task,
@@ -77,9 +81,8 @@ class MultiGPUExecutor:
         self.storage_device = storage_device
 
         self.accelerator_type = get_torch_accelerator_type()
-        torch_accelerator_module = get_torch_accelerator_module()
         if num_gpus is None:
-            num_gpus = torch_accelerator_module.device_count()
+            num_gpus = get_torch_accelerator_count()
         LOG.info(f"Using {num_gpus} {accelerator_type} for parallel execution")
 
         self.universe = TaskUniverse(targets)
@@ -344,7 +347,7 @@ class MultiGPUExecutor:
             quiet: Whether to suppress progress bar output
         """
         LOG.debug(f"Device {device} starting")
-        torch_accelerator_module = getattr(torch, self.accelerator_type)
+        torch_accelerator_module = get_torch_accelerator_module(self.accelerator_type)
         with torch.device(device):
             stream = (
                 torch.Stream(device=device)

--- a/mergekit/options.py
+++ b/mergekit/options.py
@@ -21,7 +21,7 @@ class MergeOptions(BaseModel, frozen=True):
     lora_merge_cache: Optional[str] = None
     lora_merge_dtype: Optional[str] = None
     cuda: bool = False
-    device: Optional[str] = "auto"
+    device: Optional[str] = "cpu"
     low_cpu_memory: bool = False
     out_shard_size: int = parse_kmb("5B")
     copy_tokenizer: bool = True
@@ -72,8 +72,11 @@ class MergeOptions(BaseModel, frozen=True):
         if value.get("cuda"):
             value["device"] = "cuda"
 
+        if value.get("device") is None:
+            value["device"] = "cpu"
+
         # Detect device automatically if `device` is set to "auto"
-        if value.get("device") is None or value.get("device") == "auto":
+        if value.get("device") == "auto":
             if torch.cuda.is_available():
                 value["device"] = "cuda"
             elif hasattr(torch, "xpu") and torch.xpu.is_available():
@@ -104,7 +107,7 @@ OPTION_HELP = {
     "multi_gpu": "Use multi-gpu parallel graph execution engine",
     "num_threads": "Number of threads to use for parallel CPU operations",
     "verbosity": "Verbose logging (repeat for more verbosity)",
-    "gpu_rich": "Alias for --accelerator --cuda --low-cpu-memory --read-to-gpu --multi-gpu",
+    "gpu_rich": "Alias for --cuda --low-cpu-memory --read-to-gpu --multi-gpu",
 }
 
 OPTION_CATEGORIES = {

--- a/mergekit/options.py
+++ b/mergekit/options.py
@@ -82,6 +82,7 @@ class MergeOptions(BaseModel, frozen=True):
                 value["device"] = "cpu"
         return value
 
+
 OPTION_HELP = {
     "allow_crimes": "Allow mixing architectures",
     "transformers_cache": "Override storage path for downloaded models",

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -204,7 +204,7 @@ class MergePlanner:
         gather_tensors = GatherTensors(
             weight_info=ImmutableMap(data=dict(zip(models, weights_in))),
             dtype=self.config.dtype,
-            device="cuda" if self.options.read_to_gpu else None,
+            device=self.options.device if self.options.read_to_gpu else None,
         )
 
         tensor_input_task = gather_tensors

--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -152,7 +152,9 @@ def main(
         executor = Executor(
             tasks,
             math_device=merge_options.device,
-            storage_device=merge_options.device if merge_options.low_cpu_memory else "cpu",
+            storage_device=(
+                merge_options.device if merge_options.low_cpu_memory else "cpu"
+            ),
         )
 
     module_real_ranks = {}

--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -151,8 +151,8 @@ def main(
     else:
         executor = Executor(
             tasks,
-            math_device="cuda" if merge_options.cuda else "cpu",
-            storage_device="cuda" if merge_options.low_cpu_memory else "cpu",
+            math_device=merge_options.device,
+            storage_device=merge_options.device if merge_options.low_cpu_memory else "cpu",
         )
 
     module_real_ranks = {}

--- a/mergekit/scripts/merge_raw_pytorch.py
+++ b/mergekit/scripts/merge_raw_pytorch.py
@@ -248,9 +248,8 @@ def main(
 
     executor = Executor(
         tasks,
-        math_device="cuda" if merge_options.cuda else "cpu",
-        storage_device=(
-            "cuda" if (merge_options.cuda and merge_options.low_cpu_memory) else "cpu"
+        math_device=merge_options.device,
+        storage_device=(merge_options.device if merge_options.low_cpu_memory) else "cpu"
         ),
     )
     executor.execute()

--- a/mergekit/scripts/merge_raw_pytorch.py
+++ b/mergekit/scripts/merge_raw_pytorch.py
@@ -249,7 +249,8 @@ def main(
     executor = Executor(
         tasks,
         math_device=merge_options.device,
-        storage_device=(merge_options.device if merge_options.low_cpu_memory) else "cpu"
+        storage_device=(
+            merge_options.device if merge_options.low_cpu_memory else "cpu"
         ),
     )
     executor.execute()

--- a/mergekit/scripts/multimerge.py
+++ b/mergekit/scripts/multimerge.py
@@ -117,7 +117,7 @@ def main(
 
     executor = Executor(
         tasks, math_device="cpu", storage_device="cpu"
-    )  # inner executors will handle cuda
+    )  # inner executors will handle accelerator
     executor.execute(desc="Merging models")
 
 

--- a/mergekit/scripts/tokensurgeon.py
+++ b/mergekit/scripts/tokensurgeon.py
@@ -88,7 +88,7 @@ def main(
     cache = LoaderCache()
     cache.setup(options=merge_options)
 
-    device = "cuda" if merge_options.cuda else "cpu"
+    device = merge_options.device
 
     arch_info, donor_cfg = validate_architecture(model, donor, merge_options)
     embed_info, lm_head_info = get_embedding_info(model, merge_options)


### PR DESCRIPTION
since PyTorch 2.5, xpu has been a built-in device of PyTorch.

In this PR, I extend the accelerator device of `mergekit` from CUDA only to Intel XPU(which is the name of Intel's GPU) and potentially to more devices, by adding a new `device` field in `MergeOption`.

I've passed the UT cases with

> ================== 70 passed, 2 warnings in 60.49s (0:01:00) ===================

@cg123 , pls help review and let me know what I need do next step, thx very much.