### PR TITLE
add decilm.json / nemotron arch

### DIFF
--- a/mergekit/_data/architectures/decilm.json
+++ b/mergekit/_data/architectures/decilm.json
@@ -1,0 +1,88 @@
+{
+    "model_type": "decilm",
+    "architectures": [
+        "DeciLMForCausalLM"
+    ],
+    "pre_weights": [
+        {
+            "name": "model.embed_tokens.weight",
+            "is_embed": true,
+            "output_space": "running_residual"
+        }
+    ],
+    "num_layers_config_key": "num_hidden_layers",
+    "layer_templates": {
+        "weights": [
+            {
+                "name": "model.layers.${layer_index}.input_layernorm.weight",
+                "input_space": "running_residual",
+                "optional": true
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.q_proj.weight",
+                "input_space": "running_residual",
+                "output_space": "attn_qk_${layer_index}",
+                "optional": true,
+                "head_split": "output",
+                "is_kq": true
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.k_proj.weight",
+                "input_space": "running_residual",
+                "output_space": "attn_qk_${layer_index}",
+                "optional": true,
+                "head_split": "output",
+                "is_kq": true
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.v_proj.weight",
+                "input_space": "running_residual",
+                "output_space": "attn_v_${layer_index}",
+                "optional": true,
+                "head_split": "output"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.o_proj.weight",
+                "input_space": "attn_v_${layer_index}",
+                "output_space": "running_residual",
+                "optional": true,
+                "head_split": "input"
+            },
+            {
+                "name": "model.layers.${layer_index}.post_attention_layernorm.weight",
+                "input_space": "running_residual",
+                "optional": true
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.up_proj.weight",
+                "input_space": "running_residual",
+                "output_space": "up_${layer_index}"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.gate_proj.weight",
+                "input_space": "running_residual",
+                "output_space": "up_${layer_index}"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.down_proj.weight",
+                "input_space": "up_${layer_index}",
+                "output_space": "running_residual"
+            }
+        ]
+    },
+    "post_weights": [
+        {
+            "name": "model.norm.weight",
+            "input_space": "running_residual"
+        },
+        {
+            "name": "lm_head.weight",
+            "input_space": "running_residual",
+            "is_embed": true,
+            "optional": true,
+            "tied_names": [
+                "model.embed_tokens.weight"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
bug when gguf-ing it

```
INFO:hf-to-gguf:blk.9.attn_v.weight,         torch.bfloat16 --> F32, shape = {8192, 1024}
INFO:hf-to-gguf:output_norm.weight,          torch.bfloat16 --> F32, shape = {8192}
INFO:hf-to-gguf:gguf: loading model part 'model-21.safetensors'
INFO:hf-to-gguf:blk.79.attn_q.weight,        torch.bfloat16 --> F32, shape = {8192, 8192}
Traceback (most recent call last):
  File "/workspace/./llama.cpp/convert_hf_to_gguf.py", line 6313, in <module>
    main()
  File "/workspace/./llama.cpp/convert_hf_to_gguf.py", line 6307, in main
    model_instance.write()
  File "/workspace/./llama.cpp/convert_hf_to_gguf.py", line 403, in write
    self.prepare_tensors()
  File "/workspace/./llama.cpp/convert_hf_to_gguf.py", line 2330, in prepare_tensors
    super().prepare_tensors()
  File "/workspace/./llama.cpp/convert_hf_to_gguf.py", line 365, in prepare_tensors
    self.gguf_writer.add_tensor(new_name, data, raw_dtype=data_qtype)
  File "/workspace/llama.cpp/gguf-py/gguf/gguf_writer.py", line 381, in add_tensor
    self.add_tensor_info(name, shape, tensor.dtype, tensor.nbytes, raw_dtype=raw_dtype)
  File "/workspace/llama.cpp/gguf-py/gguf/gguf_writer.py", line 332, in add_tensor_info
    raise ValueError(f'Duplicated tensor name {name!r}')
ValueError: Duplicated tensor name 'blk.79.attn_q.weight'
```