### PR TITLE
Create cohere2.json

### DIFF
--- a/mergekit/_data/architectures/cohere2.json
+++ b/mergekit/_data/architectures/cohere2.json
@@ -1,0 +1,51 @@
+{
+    "model_type": "cohere2",
+    "architectures": [
+        "Cohere2ForCausalLM"
+    ],
+    "pre_weights": [
+        {
+            "name": "model.embed_tokens.weight",
+            "is_embed": true
+        }
+    ],
+    "post_weights": [
+        {
+            "name": "model.norm.weight"
+        },
+        {
+            "name": "lm_head.weight",
+            "is_embed": true,
+            "optional": true
+        }
+    ],
+    "num_layers_config_key": "num_hidden_layers",
+    "layer_templates": {
+        "weights": [
+            {
+                "name": "model.layers.${layer_index}.self_attn.q_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.k_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.v_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.o_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.gate_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.up_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.down_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.input_layernorm.weight"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds support for the missing **Cohere2** arch template (Cohere Command A, Command R 7B). Without this addition, mergekit will fail when a merge attempt is made with models using the Cohere2ForCausalLM arch.

Credits to @drummer-v for helping troubleshooting this for me.