### PR TITLE
Fix `Unable to generate pydantic-core schema` error

### DIFF
--- a/mergekit/merge_methods/easy_define.py
+++ b/mergekit/merge_methods/easy_define.py
@@ -168,7 +168,12 @@ def __merge_method(
     tt_fields["execute"] = _execute
 
     tt_name = f"{name.title().replace(' ', '')}MergeTask"
-    tt_cls = pydantic.create_model(tt_name, __base__=Task[torch.Tensor], **tt_fields)
+    tt_cls = pydantic.create_model(
+    tt_name, 
+    __base__=Task[torch.Tensor], 
+    __config__=pydantic.ConfigDict(arbitrary_types_allowed=True),
+    **tt_fields
+)
 
     mm_fields = {}
 


### PR DESCRIPTION
This fixes the following error when working with one Gemma 3 12B model:

```
mergekit-yaml gemma.yaml ./output_directory
```

```
@workspace  language_model.model(3) 		
language_model.model.embed_tokens.weight	[262 164, 3 840]	
F16
language_model.model.layers(46) 		
language_model.model.layers.0(6) 		
language_model.model.layers.0.input_layernorm.weight	[3 840]	
F16
language_model.model.layers.0.mlp(3) 		
language_model.model.layers.0.mlp.down_proj.weight	[3 840, 15 360]	
F16
language_model.model.layers.0.mlp.gate_proj.weight	[15 360, 3 840]	
F16
language_model.model.layers.0.mlp.up_proj.weight	[15 360, 3 840]	
F16
language_model.model.layers.0.post_attention_layernorm.weight	[3 840]	
F16
language_model.model.layers.0.post_feedforward_layernorm.weight	[3 840]	
F16
language_model.model.layers.0.pre_feedforward_layernorm.weight	[3 840]	
F16
language_model.model.layers.0.self_attn(6) 		
language_model.model.layers.0.self_attn.k_norm.weight	[256]	
F16
language_model.model.layers.0.self_attn.k_proj.weight	[2 048, 3 840]	
F16
language_model.model.layers.0.self_attn.o_proj.weight	[3 840, 4 096]	
F16
language_model.model.layers.0.self_attn.q_norm.weight	[256]	
F16
language_model.model.layers.0.self_attn.q_proj.weight	[4 096, 3 840]	
F16
language_model.model.layers.0.self_attn.v_proj.weight	[2 048, 3 840]	
F16
language_model.model.layers.1(6) 		
language_model.model.layers.2(6) 		
language_model.model.layers.3(6) 		
language_model.model.layers.4(6) 		
language_model.model.layers.5(6) 		
language_model.model.layers.6(6) 		
language_model.model.layers.7(6) 		
language_model.model.layers.8(6) 		
language_model.model.layers.9(6) 		
language_model.model.layers.10(6) 		
language_model.model.layers.11(6) 		
language_model.model.layers.12(6) 		
language_model.model.layers.13(6) 		
language_model.model.layers.14(6) 		
language_model.model.layers.15(6) 		
language_model.model.layers.16(6) 		
language_model.model.layers.17(6) 		
language_model.model.layers.18(6) 		
language_model.model.layers.19(6) 		
language_model.model.layers.20(6) 		
language_model.model.layers.21(6) 		
language_model.model.layers.22(6) 		
language_model.model.layers.23(6) 		
language_model.model.layers.24(6) 		
language_model.model.layers.25(6) 		
language_model.model.layers.26(6) 		
language_model.model.layers.27(6) 		
language_model.model.layers.28(6) 		
language_model.model.layers.29(6) 		
language_model.model.layers.30(6) 		
language_model.model.layers.31(6) 		
language_model.model.layers.32(6) 		
language_model.model.layers.33(6) 		
language_model.model.layers.34(6) 		
language_model.model.layers.35(6) 		
language_model.model.layers.36(6) 		
language_model.model.layers.37(6) 		
language_model.model.layers.38(6) 		
language_model.model.layers.39(6) 		
language_model.model.layers.40(6) 		
language_model.model.layers.41(6) 		
language_model.model.layers.42(6) 		
language_model.model.layers.43(6) 		
language_model.model.layers.44(6) 		
language_model.model.layers.45(6) 		
language_model.model.norm.weight	[3 840]	
F16
multi_modal_projector(2) 		
multi_modal_projector.mm_input_projection_weight	[1 152, 3 840]	
F16
multi_modal_projector.mm_soft_emb_norm.weight	[1 152]	
F16
vision_tower.vision_model(3) 		
vision_tower.vision_model.embeddings(2) 		
vision_tower.vision_model.embeddings.patch_embedding(2) 		
vision_tower.vision_model.embeddings.patch_embedding.bias	[1 152]	
F16
vision_tower.vision_model.embeddings.patch_embedding.weight	[1 152, 3, 14, 14]	
F16
vision_tower.vision_model.embeddings.position_embedding.weight	[4 096, 1 152]	
F16
vision_tower.vision_model.encoder.layers(27) 		
vision_tower.vision_model.encoder.layers.0(3) 		
vision_tower.vision_model.encoder.layers.0.layer_norm(4) 		
vision_tower.vision_model.encoder.layers.0.layer_norm1.bias	[1 152]	
F16
vision_tower.vision_model.encoder.layers.0.layer_norm1.weight	[1 152]	
F16
vision_tower.vision_model.encoder.layers.0.layer_norm2.bias	[1 152]	
F16
vision_tower.vision_model.encoder.layers.0.layer_norm2.weight	[1 152]	
F16
vision_tower.vision_model.encoder.layers.0.mlp(4) 		
vision_tower.vision_model.encoder.layers.0.mlp.fc1.bias	[4 304]	
F16
vision_tower.vision_model.encoder.layers.0.mlp.fc1.weight	[4 304, 1 152]	
F16
vision_tower.vision_model.encoder.layers.0.mlp.fc2.bias	[1 152]	
F16
vision_tower.vision_model.encoder.layers.0.mlp.fc2.weight	[1 152, 4 304]	
F16
vision_tower.vision_model.encoder.layers.0.self_attn(8) 		
vision_tower.vision_model.encoder.layers.0.self_attn.k_proj.bias	[1 152]	
F16
vision_tower.vision_model.encoder.layers.0.self_attn.k_proj.weight	[1 152, 1 152]	
F16
vision_tower.vision_model.encoder.layers.0.self_attn.out_proj.bias	[1 152]	
F16
vision_tower.vision_model.encoder.layers.0.self_attn.out_proj.weight	[1 152, 1 152]	
F16
vision_tower.vision_model.encoder.layers.0.self_attn.q_proj.bias	[1 152]	
F16
vision_tower.vision_model.encoder.layers.0.self_attn.q_proj.weight	[1 152, 1 152]	
F16
vision_tower.vision_model.encoder.layers.0.self_attn.v_proj.bias	[1 152]	
F16
vision_tower.vision_model.encoder.layers.0.self_attn.v_proj.weight	[1 152, 1 152]	
F16
vision_tower.vision_model.encoder.layers.1(3) 		
vision_tower.vision_model.encoder.layers.2(3) 		
vision_tower.vision_model.encoder.layers.3(3) 		
vision_tower.vision_model.encoder.layers.4(3) 		
vision_tower.vision_model.encoder.layers.5(3) 		
vision_tower.vision_model.encoder.layers.6(3) 		
vision_tower.vision_model.encoder.layers.7(3) 		
vision_tower.vision_model.encoder.layers.8(3) 		
vision_tower.vision_model.encoder.layers.9(3) 		
vision_tower.vision_model.encoder.layers.10(3) 		
vision_tower.vision_model.encoder.layers.11(3) 		
vision_tower.vision_model.encoder.layers.12(3) 		
vision_tower.vision_model.encoder.layers.13(3) 		
vision_tower.vision_model.encoder.layers.14(3) 		
vision_tower.vision_model.encoder.layers.15(3) 		
vision_tower.vision_model.encoder.layers.16(3) 		
vision_tower.vision_model.encoder.layers.17(3) 		
vision_tower.vision_model.encoder.layers.18(3) 		
vision_tower.vision_model.encoder.layers.19(3) 		
vision_tower.vision_model.encoder.layers.20(3) 		
vision_tower.vision_model.encoder.layers.21(3) 		
vision_tower.vision_model.encoder.layers.22(3) 		
vision_tower.vision_model.encoder.layers.23(3) 		
vision_tower.vision_model.encoder.layers.24(3) 		
vision_tower.vision_model.encoder.layers.25(3) 		
vision_tower.vision_model.encoder.layers.26(3) 		
vision_tower.vision_model.post_layernorm(2) 		
vision_tower.vision_model.post_layernorm.bias	[1 152]	
F16
vision_tower.vision_model.post_layernorm.weight
(yuna) (base) yuki@yuki mergekit-main % mergekit-yaml loli.yaml ./output_directory
/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_fields.py:198: UserWarning: Field name "arguments" in "MultislerpMergeTask" shadows an attribute in parent "Task[Tensor]"
  warnings.warn(
/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_fields.py:198: UserWarning: Field name "group_label" in "MultislerpMergeTask" shadows an attribute in parent "Task[Tensor]"
  warnings.warn(
/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_fields.py:198: UserWarning: Field name "uses_accelerator" in "MultislerpMergeTask" shadows an attribute in parent "Task[Tensor]"
  warnings.warn(
/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_fields.py:198: UserWarning: Field name "execute" in "MultislerpMergeTask" shadows an attribute in parent "Task[Tensor]"
  warnings.warn(
Traceback (most recent call last):
  File "/opt/anaconda3/envs/yuna/bin/mergekit-yaml", line 5, in <module>
    from mergekit.scripts.run_yaml import main
  File "/Users/yuki/Downloads/mergekit-main/mergekit/scripts/run_yaml.py", line 9, in <module>
    from mergekit.merge import run_merge
  File "/Users/yuki/Downloads/mergekit-main/mergekit/merge.py", line 17, in <module>
    from mergekit.card import generate_card
  File "/Users/yuki/Downloads/mergekit-main/mergekit/card.py", line 12, in <module>
    from mergekit import merge_methods
  File "/Users/yuki/Downloads/mergekit-main/mergekit/merge_methods/__init__.py", line 4, in <module>
    import mergekit.merge_methods.multislerp
  File "/Users/yuki/Downloads/mergekit-main/mergekit/merge_methods/multislerp.py", line 16, in <module>
    def multislerp(
  File "/Users/yuki/Downloads/mergekit-main/mergekit/merge_methods/easy_define.py", line 313, in _wrap
    return __merge_method(func, name, reference_url, pretty_name)
  File "/Users/yuki/Downloads/mergekit-main/mergekit/merge_methods/easy_define.py", line 171, in __merge_method
    tt_cls = pydantic.create_model(tt_name, __base__=Task[torch.Tensor], **tt_fields)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/main.py", line 1763, in create_model
    return meta(
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_model_construction.py", line 237, in __new__
    complete_model_class(
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_model_construction.py", line 597, in complete_model_class
    schema = gen_schema.generate_schema(cls)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 711, in generate_schema
    schema = self._generate_schema_inner(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1004, in _generate_schema_inner
    return self._model_schema(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 837, in _model_schema
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 837, in <dictcomp>
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1206, in _generate_md_field_schema
    common_field = self._common_field_schema(name, field_info, decorators)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1372, in _common_field_schema
    schema = self._apply_annotations(
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 2297, in _apply_annotations
    schema = get_inner_schema(source_type)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_schema_generation_shared.py", line 83, in __call__
    schema = self._handler(source_type)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 2279, in inner_handler
    schema = self._generate_schema_inner(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1009, in _generate_schema_inner
    return self.match_type(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1110, in match_type
    return self._call_schema(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 2007, in _call_schema
    arguments_schema = self._arguments_schema(function)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 2059, in _arguments_schema
    arg_schema = self._generate_parameter_schema(
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1655, in _generate_parameter_schema
    schema = self._apply_annotations(field.annotation, [field])
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 2297, in _apply_annotations
    schema = get_inner_schema(source_type)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_schema_generation_shared.py", line 83, in __call__
    schema = self._handler(source_type)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 2373, in new_handler
    schema = get_inner_schema(source)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_schema_generation_shared.py", line 83, in __call__
    schema = self._handler(source_type)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 2279, in inner_handler
    schema = self._generate_schema_inner(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1009, in _generate_schema_inner
    return self.match_type(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1123, in match_type
    return self._match_generic_type(obj, origin)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1156, in _match_generic_type
    return self._dict_schema(*self._get_first_two_args_or_any(obj))
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 375, in _dict_schema
    return core_schema.dict_schema(self.generate_schema(keys_type), self.generate_schema(values_type))
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 711, in generate_schema
    schema = self._generate_schema_inner(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1009, in _generate_schema_inner
    return self.match_type(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 1127, in match_type
    return self._unknown_type_schema(obj)
  File "/opt/anaconda3/envs/yuna/lib/python3.10/site-packages/pydantic/_internal/_generate_schema.py", line 639, in _unknown_type_schema
    raise PydanticSchemaGenerationError(
pydantic.errors.PydanticSchemaGenerationError: Unable to generate pydantic-core schema for <class 'torch.Tensor'>. Set `arbitrary_types_allowed=True` in the model_config to ignore this error or implement `__get_pydantic_core_schema__` on your type to fully support it.

If you got this error by calling handler(<some type>) within `__get_pydantic_core_schema__` then you likely need to call `handler.generate_schema(<some type>)` since we do not call `__get_pydantic_core_schema__` on `<some type>` otherwise to avoid infinite recursion.

For further information visit https://errors.pydantic.dev/2.11/u/schema-for-unknown-type
(yuna) (base) yuki@yuki mergekit-main % 
```