### PR TITLE
Make parameters config optional in RawPyTorchMergeConfig.

### DIFF
--- a/mergekit/scripts/merge_raw_pytorch.py
+++ b/mergekit/scripts/merge_raw_pytorch.py
@@ -28,8 +28,8 @@ class InputModelDefinition(BaseModel, frozen=True):
 
 class RawPyTorchMergeConfig(BaseModel, frozen=True):
     merge_method: str
-    parameters: Optional[Dict[str, ParameterSetting]]
     models: List[InputModelDefinition]
+    parameters: Optional[Dict[str, ParameterSetting]] = None
     dtype: Optional[str] = None
     base_model: Optional[str] = None
 
@@ -169,7 +169,7 @@ def construct_param_dicts(
 ):
     global_params = {}
     for param_def in merge_method.parameters():
-        if param_def.name in config.parameters:
+        if config.parameters and param_def.name in config.parameters:
             value = evaluate_setting(tensor_name, config.parameters[param_def.name])
             if value is not None:
                 global_params[param_def.name] = value


### PR DESCRIPTION
In contrast to `merge-yaml` the `merge-pytorch` configuration has non-nullable `parameters` value ([MergeConfiguration L99](https://github.com/arcee-ai/mergekit/blob/main/mergekit/config.py#L99) vs [RawPyTorchMergeConfig L31](https://github.com/arcee-ai/mergekit/blob/main/mergekit/scripts/merge_raw_pytorch.py#L31)).

The change adds possibility to provide empty `parameters` value during `merge-pytorch` and passes all the tests.