### PR TITLE
Fix auto-architecture for MoE models

### DIFF
--- a/mergekit/architecture/auto.py
+++ b/mergekit/architecture/auto.py
@@ -125,7 +125,7 @@ def infer_architecture_info(
                 module_layer_counts[prefix], layer_idx + 1
             )
             module_templates[prefix] = module_templates[prefix].union(
-                set([RE_LAYER_INDEX.sub(".${layer_index}.", tensor_name)])
+                set([RE_LAYER_INDEX.sub(".${layer_index}.", tensor_name, count=1)])
             )
 
     if len(module_prefixes) == 1:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Allows tensor names with multiple layer indices and substitutes only the first occurrence when generating layer templates.
> 
> - **Auto-architecture inference (`mergekit/architecture/auto.py`)**:
>   - Remove check that raised on tensor names containing more than one layer index.
>   - When building `module_templates`, replace only the first matched layer index (`count=1`) in `RE_LAYER_INDEX.sub`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5833f5e0fa93d314fcd6813a9451450eb26bcde0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->