### PR TITLE
Reformated mergekit

### DIFF
--- a/mergekit/merge_methods/sce.py
+++ b/mergekit/merge_methods/sce.py
@@ -38,11 +38,7 @@ def sce_merge(
         # Handle shape mismatch - resize to base dimensions
         if t.shape != base_tensor.shape:
             # Slice tensor to match base_tensor dimensions
-            slices = tuple(
-                slice(0, min(t.shape[i], base_tensor.shape[i]))
-                for i in range(len(base_tensor.shape))
-            )
-            t = t[slices]
+            t = t[: base_tensor.shape[0], : base_tensor.shape[1]]
             logging.warning(f"Using submatrix of tensor {idx}")
 
         # Compute task vector (delta)


### PR DESCRIPTION
## Summary
Standardizes task vector extraction in SCE to use the same logic in `get_task_vectors` function from `generalized_task_arithmetic.py`, adding submatrix support that was previously missing.

## Problem
- SCE currently uses an independent implementation for extracting task vectors
- This independent implementation lacks submatrix support
- The `get_task_vectors` function in `generalized_task_arithmetic.py` already provides this functionality
- Code duplication creates maintenance overhead and feature inconsistency, at some point SCE should benefit from the `generalized_task_arithmetic.py` implementations

## Solution
- Added submatrix support for SCE such as in the existing `get_task_vectors` function
- Ensures consistent logic across both implementations
- Adds submatrix support to SCE operations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dtype normalization and submatrix handling when constructing SCE task vectors, preserving existing masking/weighting logic.
> 
> - **SCE merge (`mergekit/merge_methods/sce.py`)**:
>   - Normalize tensor dtypes to `base_tensor.dtype` and handle shape mismatches by slicing to a submatrix; emit warnings via `logging`.
>   - Build task vectors only from validated tensors and early-return to base when none remain; stack into `task_vectors`.
>   - Preserve existing flow: optional top-k masking (`sce_mask`), sign-consensus erase mask, weighting (`sce_weight`), and merge computation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5ff3826e4a21ff81c6400d21511b206a79aeab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->