### PR TITLE
Add ApertusForCausalLM

### DIFF
--- a/mergekit/_data/architectures/apertus.json
+++ b/mergekit/_data/architectures/apertus.json
@@ -1,0 +1,72 @@
+{
+    "model_type": "apertus",
+    "architectures": [
+        "ApertusForCausalLM"
+    ],
+    "pre_weights": [
+        {
+            "name": "model.embed_tokens.weight",
+            "is_embed": true
+        }
+    ],
+    "post_weights": [
+        {
+            "name": "model.norm.weight"
+        },
+        {
+            "name": "lm_head.weight",
+            "is_embed": true,
+            "optional": true,
+            "tied_names": [
+                "model.embed_tokens.weight"
+            ]
+        }
+    ],
+    "num_layers_config_key": "num_hidden_layers",
+    "layer_templates": {
+        "weights": [
+            {
+                "name": "model.layers.${layer_index}.attention_layernorm.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.feedforward_layernorm.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.act_fn.alpha_n"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.act_fn.alpha_p"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.act_fn.beta"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.act_fn.eps"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.down_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.mlp.up_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.k_norm.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.k_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.q_norm.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.q_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.v_proj.weight"
+            },
+            {
+                "name": "model.layers.${layer_index}.self_attn.o_proj.weight"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `apertus` architecture config with weight mappings and per-layer templates for `ApertusForCausalLM`.
> 
> - **Architectures**:
>   - Add `mergekit/_data/architectures/apertus.json` defining `model_type: apertus` for `ApertusForCausalLM`.
>   - Configure weight mapping:
>     - Pre: `model.embed_tokens.weight` (embed).
>     - Post: `model.norm.weight`, `lm_head.weight` (embed, optional, tied to `model.embed_tokens.weight`).
>   - Set `num_layers_config_key: num_hidden_layers` and per-layer templates for norms, MLP (`act_fn.alpha_n`, `alpha_p`, `beta`, `eps`, `down_proj.weight`, `up_proj.weight`) and attention (`k/q` norms, `k/q/v/o` proj weights).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93d80114dc2d146985a8f83d11350f424618f77f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->