### PR TITLE
Bug fix: Filter tokens not in the embedding (tokensurgeon)

### DIFF
--- a/mergekit/scripts/tokensurgeon.py
+++ b/mergekit/scripts/tokensurgeon.py
@@ -462,7 +462,10 @@ def build_embedding_matrix(
         ):
             res[donor_idx] = orig_embed[orig_idx]
             stats.byte_match += 1
-        elif allow_prefix and (orig_idx := match_prefix(token, safe_orig_vocab)) is not None:
+        elif (
+            allow_prefix
+            and (orig_idx := match_prefix(token, safe_orig_vocab)) is not None
+        ):
             res[donor_idx] = orig_embed[orig_idx]
             stats.prefix_match += 1
         else:


### PR DESCRIPTION
I recently attempted to use `google/gemma-3-1b-it` as a donor model for a transplant into other models (I use a Qwen2-0.5B base for the experiment below). The process consistently crashed partway through the OMP approximation step with a `device-side assert`.

### The Crash

The error was a CUDA index out-of-bounds assertion failure during the gather operation on the donor embeddings.

```text
pytorch/aten/src/ATen/native/cuda/IndexKernelUtils.cu:16: vectorized_gather_kernel: block: [210,0,0], thread: [158,0,0] Assertion `ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds"` failed.
pytorch/aten/src/ATen/native/cuda/IndexKernelUtils.cu:16: vectorized_gather_kernel: block: [210,0,0], thread: [159,0,0] Assertion `ind >=0 && ind < ind_dim_size && "vectorized gather kernel index out of bounds"` failed.
Approximating tokens:  87%|██████████████████████████████████████████████████████████████          | 339/388 [02:37<00:22,  2.15it/s]
Traceback (most recent call last):
  File ".../envs/mergekit-py313/bin/mergekit-tokensurgeon", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File ".../envs/mergekit-py313/lib/python3.13/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
            ~~~~~~~~~^^^^^^^^^^^^^^^^^
  ...
  File ".../mergekit/mergekit/scripts/tokensurgeon.py", line 465, in build_embedding_matrix
    new_embeds = compute_new_embeddings(
        orig_embed,
    ...<7 lines>...
        options=options,
    )
  File ".../mergekit/mergekit/scripts/tokensurgeon.py", line 341, in compute_new_embeddings
    indices, coeffs = batch_omp(targets, donor_shared_embeds, options.k)
                      ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../mergekit/mergekit/tokensurgeon/omp.py", line 65, in batch_omp
    mask[torch.arange(B, device=device), new_idx] = True
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch.AcceleratorError: CUDA error: device-side assert triggered

```

### The Investigation

Upon closer inspection of the Gemma-3 tokenizer and model config, I found an off-by-one discrepancy.

* **Embedding Rows:** `262144`
* **Tokenizer Vocab:** Includes a special token `<image_soft_token>` at ID `262144`.

The tokenizer reports a vocabulary size that is technically one larger than the embedding matrix provided in the text-only weights. When TokenSurgeon attempted to look up this ID in the donor's embedding table, it tried to access row `262144` (the 262,145th row), which does not exist, causing the crash.

## The Fix

I have updated `build_embedding_matrix` to strictly validate donor and original token IDs against their respective embedding table sizes before processing.

1. **Safety Filter:** Added a check to identify IDs `>= embedding_rows`.
2. **Graceful Exclusion:** These OOB tokens are now filtered out of the candidate set for OMP. They are effectively treated as "junk" tokens for the purpose of the transplant.
3. **Logging:** A warning is now emitted to inform the user that specific tokens were skipped due to being out of bounds.

### Verification

Running the same merge command with these changes now completes successfully, skipping the single problematic token in Gemma-3.

```text
WARNING:root:This script is experimental and may produce unexpected results.
Fetching 6 files: 100%|████████████████████████████████████████████████████████████████████████████| 6/6 [00:00<00:00, 94608.36it/s]
Fetching 8 files: 100%|████████████████████████████████████████████████████████████████████████████| 8/8 [00:00<00:00, 77492.91it/s]
WARNING:mergekit.scripts.tokensurgeon:Skipping 1 donor tokens with ids >= 262144 rows for model.embed_tokens.weight
Approximating tokens: 100%|███████████████████████████████████████████████████████████████████████| 388/388 [03:01<00:00,  2.14it/s]
Saving weights: 100%|████████████████████████████████████████████████████████████████████████████| 291/291 [00:00<00:00, 491.97it/s]
lm-eval not installed; skipping evaluation.

```

## Summary of Changes

* Prevent OOB index errors when donor token IDs exceed embedding rows.
* Filter out donor/original vocab entries with IDs beyond their embedding tables.
* Keep output vocab size aligned to donor tokenizer; OOB rows remain zero-initialized.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents out-of-bounds indexing during token approximation by sanitizing vocab-to-id mappings.
> 
> - Build `safe_orig_vocab`/`safe_donor_vocab` by filtering IDs >= `orig_embed.shape[0]`/`donor_embed.shape[0]`; warn on dropped tokens
> - Skip donor tokens with out-of-range indices; add their IDs to `junk_tokens` and zero-initialize them later
> - Pass safe vocabs to `compute_token_basis` and `compute_new_embeddings`; update byte/prefix matching to use `safe_orig_vocab`
> - Keep output tensor sized to donor vocab while filling valid rows and approximating only safe new tokens
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f09f31775f509b76ac64945562c21a452cb5233. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->