### PR TITLE
Add Qwen3-VL dense models

### DIFF
--- a/mergekit/_data/architectures/qwen3_vl_dense.json
+++ b/mergekit/_data/architectures/qwen3_vl_dense.json
@@ -1,0 +1,192 @@
+{
+    "kind": "modular",
+    "model_type": "qwen3_vl",
+    "architectures": [
+        "Qwen3VLForConditionalGeneration"
+    ],
+    "num_vision_layers_config_key": "vision_config.depth",
+    "vocab_size_config_key": "text_config.vocab_size",
+    "tagalong_files": [
+        "preprocessor_config.json",
+        "vocab.json"
+    ],
+    "modules": {
+        "text_decoder": {
+            "architecture": {
+                "architectures": [
+                    "Qwen3ForCausalLM"
+                ],
+                "model_type": "qwen3_vl_text",
+                "num_layers_config_key": "text_config.num_hidden_layers",
+                "pre_weights": [
+                    {
+                        "name": "model.language_model.embed_tokens.weight",
+                        "is_embed": true
+                    }
+                ],
+                "post_weights": [
+                    {
+                        "name": "model.language_model.norm.weight"
+                    },
+                    {
+                        "name": "lm_head.weight",
+                        "is_embed": true,
+                        "optional": true,
+                        "tied_names": [
+                            "model.language_model.embed_tokens.weight"
+                        ]
+                    }
+                ],
+                "layer_templates": {
+                    "weights": [
+                        {
+                            "name": "model.language_model.layers.${layer_index}.input_layernorm.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.mlp.down_proj.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.mlp.gate_proj.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.mlp.up_proj.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.post_attention_layernorm.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.self_attn.k_norm.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.self_attn.k_proj.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.self_attn.o_proj.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.self_attn.q_norm.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.self_attn.q_proj.weight"
+                        },
+                        {
+                            "name": "model.language_model.layers.${layer_index}.self_attn.v_proj.weight"
+                        }
+                    ]
+                }
+            }
+        },
+        "multi_modal_projector": {
+            "model_type": "",
+            "architecture": {
+                "model_type": "",
+                "architectures": [],
+                "override_num_layers": 3,
+                "pre_weights": [
+                    {
+                        "name": "model.visual.merger.norm.weight"
+                    },
+                    {
+                        "name": "model.visual.merger.norm.bias"
+                    },
+                    {
+                        "name": "model.visual.merger.linear_fc1.weight"
+                    },
+                    {
+                        "name": "model.visual.merger.linear_fc1.bias"
+                    },
+                    {
+                        "name": "model.visual.merger.linear_fc2.weight"
+                    },
+                    {
+                        "name": "model.visual.merger.linear_fc2.bias"
+                    }
+                ],
+                "post_weights": [],
+                "layer_templates": {
+                    "weights": [
+                        {
+                            "name": "model.visual.deepstack_merger_list.${layer_index}.norm.weight"
+                        },
+                        {
+                            "name": "model.visual.deepstack_merger_list.${layer_index}.norm.bias"
+                        },
+                        {
+                            "name": "model.visual.deepstack_merger_list.${layer_index}.linear_fc1.weight"
+                        },
+                        {
+                            "name": "model.visual.deepstack_merger_list.${layer_index}.linear_fc1.bias"
+                        },
+                        {
+                            "name": "model.visual.deepstack_merger_list.${layer_index}.linear_fc2.weight"
+                        },
+                        {
+                            "name": "model.visual.deepstack_merger_list.${layer_index}.linear_fc2.bias"
+                        }
+                    ]
+                }
+            }
+        },
+        "vision_tower": {
+            "architecture": {
+                "model_type": "",
+                "architectures": [],
+                "num_layers_config_key": "vision_config.depth",
+                "pre_weights": [
+                    {
+                        "name": "model.visual.patch_embed.proj.weight",
+                        "is_embed": true
+                    },
+                    {
+                        "name": "model.visual.patch_embed.proj.bias"
+                    },
+                    {
+                        "name": "model.visual.pos_embed.weight",
+                        "is_embed": true
+                    }
+                ],
+                "post_weights": [],
+                "layer_templates": {
+                    "weights": [
+                        {
+                            "name": "model.visual.blocks.${layer_index}.norm1.weight"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.norm1.bias"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.norm2.weight"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.norm2.bias"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.attn.qkv.weight"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.attn.qkv.bias"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.attn.proj.weight"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.attn.proj.bias"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.mlp.linear_fc1.weight"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.mlp.linear_fc1.bias"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.mlp.linear_fc2.weight"
+                        },
+                        {
+                            "name": "model.visual.blocks.${layer_index}.mlp.linear_fc2.bias"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add support for Qwen3-VL dense models, locally tested with Qwen3-VL-4B-Instruct, Qwen3-VL-8B-Thinking, Qwen3-VL-32B-Instruct. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new architecture JSON that affects how MergeKit identifies and maps Qwen3-VL dense model weights; incorrect keys/weight names could break loading or merges for these models. Change is isolated to data/config with no broader code logic modifications.
> 
> **Overview**
> Adds a new modular architecture definition `qwen3_vl_dense.json` to support **dense Qwen3-VL** models (`Qwen3VLForConditionalGeneration`).
> 
> The definition introduces module weight mappings for the text decoder (dense MLP projections), the multi-modal projector (deepstack merger layers), and the vision tower blocks, along with updated config keys for `vision_config.depth` and `text_config.vocab_size` and required tagalong files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1f257fe51afb04d8f6900a108ca8d3a76cb9da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->