### PR TITLE
Fix TypeError when loading model in MoE router without bitsandbytes

### DIFF
--- a/mergekit/moe/router.py
+++ b/mergekit/moe/router.py
@@ -113,15 +113,19 @@ def get_gate_params(
             )
 
     elif mode in ("hidden", "hidden_avg", "hidden_last"):
+        kwargs = {}
+        if load_in_4bit:
+            kwargs["load_in_4bit"] = True
+        if load_in_8bit:
+            kwargs["load_in_8bit"] = True
         model = AutoModelForCausalLM.from_pretrained(
             model_ref.model.path,
             revision=model_ref.model.revision,
             torch_dtype=torch.bfloat16,
             device_map=device,
             low_cpu_mem_usage=True,
-            load_in_4bit=load_in_4bit,
-            load_in_8bit=load_in_8bit,
             trust_remote_code=trust_remote_code,
+            **kwargs,
         )
 
         def _do_it(tokenized):


### PR DESCRIPTION
I was trying to run `mergekit-moe` to merge some Qwen models on my CPU. Even though I wasn't using any 4-bit or 8-bit quantization flags, the merge kept crashing with:
`TypeError: Qwen2ForCausalLM.__init__() got an unexpected keyword argument 'load_in_4bit'`

It turns out that `mergekit` was passing `load_in_4bit=False` and `load_in_8bit=False` by default to the Hugging Face `from_pretrained` method. In newer versions of `transformers`, passing these options when you don't have a CUDA GPU or `bitsandbytes` configured causes a crash because the library doesn't know what to do with them.

Instead of always passing `load_in_4bit` and `load_in_8bit` as `False`, this change constructs the arguments dynamically. They are only sent to `from_pretrained` if they are set to `True`. 
This keeps CPU merges (and any merge not using quantization) running smoothly without crashing!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to optional kwargs for model loading; behavior unchanged when 4/8-bit flags are explicitly enabled.
> 
> **Overview**
> Fixes CPU / non-quantized MoE routing by **only passing `load_in_4bit` and `load_in_8bit` to `AutoModelForCausalLM.from_pretrained` when those flags are `True`**, instead of always forwarding them as `False`.
> 
> In `get_gate_params` (hidden / hidden_avg / hidden_last modes), quantization options are collected in a `kwargs` dict and spread into `from_pretrained`, so models like Qwen2 no longer receive unsupported keyword arguments on CPU or without bitsandbytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07bae365ecfc6f2632963f993d84744005a5a994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->