### PR TITLE
Bump copyright date

### DIFF
--- a/mergekit/architecture/__init__.py
+++ b/mergekit/architecture/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/architecture/auto.py
+++ b/mergekit/architecture/auto.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/architecture/base.py
+++ b/mergekit/architecture/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from abc import ABC, abstractmethod

--- a/mergekit/architecture/conversion.py
+++ b/mergekit/architecture/conversion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import re

--- a/mergekit/architecture/json_definitions.py
+++ b/mergekit/architecture/json_definitions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import importlib

--- a/mergekit/architecture/moe_defs.py
+++ b/mergekit/architecture/moe_defs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import ClassVar, List, Optional

--- a/mergekit/card.py
+++ b/mergekit/card.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import os

--- a/mergekit/common.py
+++ b/mergekit/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import binascii

--- a/mergekit/config.py
+++ b/mergekit/config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union

--- a/mergekit/evo/actors.py
+++ b/mergekit/evo/actors.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import gc

--- a/mergekit/evo/config.py
+++ b/mergekit/evo/config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/evo/genome.py
+++ b/mergekit/evo/genome.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/evo/helpers.py
+++ b/mergekit/evo/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/evo/monkeypatch.py
+++ b/mergekit/evo/monkeypatch.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 

--- a/mergekit/evo/strategy.py
+++ b/mergekit/evo/strategy.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import asyncio

--- a/mergekit/graph.py
+++ b/mergekit/graph.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 """
 Module for computational graph execution.

--- a/mergekit/io/__init__.py
+++ b/mergekit/io/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from mergekit.io.lazy_tensor_loader import (

--- a/mergekit/io/lazy_tensor_loader.py
+++ b/mergekit/io/lazy_tensor_loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import json

--- a/mergekit/io/lazy_unpickle.py
+++ b/mergekit/io/lazy_unpickle.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import codecs

--- a/mergekit/io/loader.py
+++ b/mergekit/io/loader.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from abc import ABC, abstractmethod

--- a/mergekit/io/tasks.py
+++ b/mergekit/io/tasks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import os

--- a/mergekit/io/tensor_writer.py
+++ b/mergekit/io/tensor_writer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import json

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import importlib

--- a/mergekit/merge_methods/__init__.py
+++ b/mergekit/merge_methods/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import mergekit.merge_methods.multislerp

--- a/mergekit/merge_methods/arcee_fusion.py
+++ b/mergekit/merge_methods/arcee_fusion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import Dict, List, Optional

--- a/mergekit/merge_methods/base.py
+++ b/mergekit/merge_methods/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from abc import ABC, abstractmethod

--- a/mergekit/merge_methods/easy_define.py
+++ b/mergekit/merge_methods/easy_define.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import inspect

--- a/mergekit/merge_methods/generalized_task_arithmetic.py
+++ b/mergekit/merge_methods/generalized_task_arithmetic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/merge_methods/karcher.py
+++ b/mergekit/merge_methods/karcher.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import Any, Dict, List, Optional

--- a/mergekit/merge_methods/linear.py
+++ b/mergekit/merge_methods/linear.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import Any, Dict, List, Optional

--- a/mergekit/merge_methods/model_stock.py
+++ b/mergekit/merge_methods/model_stock.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/merge_methods/multislerp.py
+++ b/mergekit/merge_methods/multislerp.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import List, Optional

--- a/mergekit/merge_methods/nearswap.py
+++ b/mergekit/merge_methods/nearswap.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import List

--- a/mergekit/merge_methods/nuslerp.py
+++ b/mergekit/merge_methods/nuslerp.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import Any, Dict, List, Optional

--- a/mergekit/merge_methods/passthrough.py
+++ b/mergekit/merge_methods/passthrough.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import Any, Dict, List, Optional

--- a/mergekit/merge_methods/ram.py
+++ b/mergekit/merge_methods/ram.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import List, Tuple

--- a/mergekit/merge_methods/rectify_embed.py
+++ b/mergekit/merge_methods/rectify_embed.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 

--- a/mergekit/merge_methods/registry.py
+++ b/mergekit/merge_methods/registry.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import Dict, List

--- a/mergekit/merge_methods/sce.py
+++ b/mergekit/merge_methods/sce.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import List, Optional

--- a/mergekit/merge_methods/slerp.py
+++ b/mergekit/merge_methods/slerp.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import Any, Dict, List, Optional, Union

--- a/mergekit/moe/arch.py
+++ b/mergekit/moe/arch.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from abc import ABC, abstractmethod

--- a/mergekit/moe/common.py
+++ b/mergekit/moe/common.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/moe/config.py
+++ b/mergekit/moe/config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/moe/deepseek.py
+++ b/mergekit/moe/deepseek.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import json

--- a/mergekit/moe/mixtral.py
+++ b/mergekit/moe/mixtral.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/moe/qwen.py
+++ b/mergekit/moe/qwen.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/moe/qwen3.py
+++ b/mergekit/moe/qwen3.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/moe/router.py
+++ b/mergekit/moe/router.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/multigpu_executor.py
+++ b/mergekit/multigpu_executor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 """
 Implementation of multi-GPU parallel task execution.

--- a/mergekit/options.py
+++ b/mergekit/options.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import functools

--- a/mergekit/plan.py
+++ b/mergekit/plan.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/scripts/bakllama.py
+++ b/mergekit/scripts/bakllama.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import List, Optional

--- a/mergekit/scripts/evolve.py
+++ b/mergekit/scripts/evolve.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import importlib.util

--- a/mergekit/scripts/extract_lora.py
+++ b/mergekit/scripts/extract_lora.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import json

--- a/mergekit/scripts/fill_missing_params.py
+++ b/mergekit/scripts/fill_missing_params.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 import logging
 import shutil

--- a/mergekit/scripts/layershuffle.py
+++ b/mergekit/scripts/layershuffle.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import random

--- a/mergekit/scripts/legacy.py
+++ b/mergekit/scripts/legacy.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import List, Optional

--- a/mergekit/scripts/merge_raw_pytorch.py
+++ b/mergekit/scripts/merge_raw_pytorch.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/scripts/moe.py
+++ b/mergekit/scripts/moe.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/scripts/multimerge.py
+++ b/mergekit/scripts/multimerge.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/scripts/run_yaml.py
+++ b/mergekit/scripts/run_yaml.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 

--- a/mergekit/scripts/tokensurgeon.py
+++ b/mergekit/scripts/tokensurgeon.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import enum

--- a/mergekit/sparsify.py
+++ b/mergekit/sparsify.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from enum import Enum

--- a/mergekit/tokenizer/__init__.py
+++ b/mergekit/tokenizer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import mergekit.tokenizer.normalization as normalization

--- a/mergekit/tokenizer/build.py
+++ b/mergekit/tokenizer/build.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import json

--- a/mergekit/tokenizer/config.py
+++ b/mergekit/tokenizer/config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from typing import Dict, Optional, Union

--- a/mergekit/tokenizer/embed.py
+++ b/mergekit/tokenizer/embed.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/tokensurgeon/__init__.py
+++ b/mergekit/tokensurgeon/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from .common_interpolation import (

--- a/mergekit/tokensurgeon/common_interpolation.py
+++ b/mergekit/tokensurgeon/common_interpolation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import enum

--- a/mergekit/tokensurgeon/omp.py
+++ b/mergekit/tokensurgeon/omp.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/tokensurgeon/pca.py
+++ b/mergekit/tokensurgeon/pca.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import logging

--- a/mergekit/tokensurgeon/subword.py
+++ b/mergekit/tokensurgeon/subword.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2025 Arcee AI
+# Copyright (C) 2026 Arcee AI
 # SPDX-License-Identifier: LGPL-3.0-only
 
 import enum


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Header-only metadata change with no impact on merge logic, security, or data handling.
> 
> **Overview**
> Updates the Arcee AI copyright notice from **2025** to **2026** in the first-line header of Python modules under `mergekit/` (architecture, io, merge methods, evo, moe, scripts, tokenizer, tokensurgeon, and related packages). The `LGPL-3.0-only` SPDX line is unchanged.
> 
> There is no change to runtime behavior, APIs, or dependencies—only license header metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32470cecc25cd4401cfd364f3bbfc692ce3a0296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->