### PR TITLE
Fix `PydanticUndefinedAnnotation` error under transformers>=5

### DIFF
--- a/mergekit/architecture/base.py
+++ b/mergekit/architecture/base.py
@@ -2,13 +2,19 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple
+from typing import Annotated, Dict, List, Optional, Tuple
 
-import torch  # noqa: F401
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, GetPydanticSchema
+from pydantic_core import core_schema
 from transformers import PretrainedConfig
 
 from mergekit.common import get_config_value
+
+# PretrainedConfig became a dataclass in transformers>=5 with a TYPE_CHECKING-only torch reference, which breaks pydantic's default schema resolution; treat it as opaque instead.
+_ConfigField = Annotated[
+    PretrainedConfig,
+    GetPydanticSchema(lambda tp, _handler: core_schema.is_instance_schema(tp)),
+]
 
 
 class WeightInfo(BaseModel, frozen=True):
@@ -87,7 +93,7 @@ class ConfiguredModuleArchitecture(
     BaseModel, frozen=True, arbitrary_types_allowed=True
 ):
     info: ModuleArchitecture
-    config: PretrainedConfig
+    config: _ConfigField
     weight_prefix: Optional[str] = None
 
     def num_layers(self) -> int:
@@ -141,7 +147,7 @@ class ModelArchitecture(BaseModel, frozen=True):
 
 class ConfiguredModelArchitecture(BaseModel, frozen=True, arbitrary_types_allowed=True):
     info: ModelArchitecture
-    config: PretrainedConfig
+    config: _ConfigField
 
     def all_weights(self) -> List[WeightInfo]:
         return self.info.all_weights(self.config)

--- a/tests/test_architecture_pydantic_schema.py
+++ b/tests/test_architecture_pydantic_schema.py
@@ -1,0 +1,13 @@
+from mergekit.architecture.base import (
+    ConfiguredModelArchitecture,
+    ConfiguredModuleArchitecture,
+)
+
+
+def test_configured_architecture_schema_rebuilds_cleanly():
+    # transformers>=5 made PretrainedConfig a dataclass with a torch reference that's
+    # only available under TYPE_CHECKING; pydantic's default schema resolution used to
+    # choke on it (see arcee-ai/mergekit#681). A forced rebuild reproduces this
+    # regardless of any caching from earlier, successful schema builds in-process.
+    ConfiguredModuleArchitecture.model_rebuild(force=True)
+    ConfiguredModelArchitecture.model_rebuild(force=True)

--- a/tests/test_architecture_pydantic_schema.py
+++ b/tests/test_architecture_pydantic_schema.py
@@ -1,13 +1,32 @@
+import pytest
+from pydantic import ValidationError
+
 from mergekit.architecture.base import (
     ConfiguredModelArchitecture,
     ConfiguredModuleArchitecture,
+    ModuleArchitecture,
 )
 
 
 def test_configured_architecture_schema_rebuilds_cleanly():
-    # transformers>=5 made PretrainedConfig a dataclass with a torch reference that's
-    # only available under TYPE_CHECKING; pydantic's default schema resolution used to
-    # choke on it (see arcee-ai/mergekit#681). A forced rebuild reproduces this
-    # regardless of any caching from earlier, successful schema builds in-process.
+    # transformers>=5 made PretrainedConfig a dataclass with a torch reference only available under TYPE_CHECKING, which used to break pydantic's schema resolution (arcee-ai/mergekit#681); a forced rebuild reproduces this regardless of caching from an earlier successful build.
     ConfiguredModuleArchitecture.model_rebuild(force=True)
     ConfiguredModelArchitecture.model_rebuild(force=True)
+
+
+class _StubModuleArchitecture(ModuleArchitecture):
+    def pre_weights(self, config):
+        return []
+
+    def post_weights(self, config):
+        return []
+
+    def layer_weights(self, index, config):
+        return []
+
+
+def test_configured_module_architecture_rejects_non_pretrainedconfig():
+    with pytest.raises(ValidationError):
+        ConfiguredModuleArchitecture(
+            info=_StubModuleArchitecture(), config="not a config"
+        )


### PR DESCRIPTION
Hi!

transformers>=5 made `PretrainedConfig` a dataclass whose own fields reference `torch` only under `TYPE_CHECKING`. Pydantic's default schema generation for `ConfiguredModuleArchitecture`/`ConfiguredModelArchitecture` tries to resolve those annotations and crashes with `PydanticUndefinedAnnotation: name 'torch' is not defined` (#681).

#692 works around this by importing `torch` at module load, which happens to let pydantic's cached schema build succeed, but a forced rebuild still crashes, so it's one caching change away from breaking again. This makes `config` an opaque, isinstance-checked field instead, so pydantic never touches `PretrainedConfig`'s internals, and drops the now-unnecessary `torch` import. Added a regression test that reproduces the crash on a forced rebuild, plus a check that invalid values are still correctly rejected.

Credit: @wmoell1 and @c1ydehhx's diagnosis in #681.

Fixes #681.

Happy to adjust anything here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow compatibility fix for Pydantic schema generation; runtime behavior for valid `PretrainedConfig` instances is unchanged aside from validation path.
> 
> **Overview**
> Fixes **PydanticUndefinedAnnotation** when building schemas for `ConfiguredModuleArchitecture` and `ConfiguredModelArchitecture` with **transformers>=5**, where `PretrainedConfig` is a dataclass whose fields reference `torch` only under `TYPE_CHECKING`.
> 
> The `config` field on those models now uses an opaque **`_ConfigField`** (`Annotated` + `GetPydanticSchema` / `is_instance_schema`) so Pydantic validates with `isinstance` instead of introspecting `PretrainedConfig`. The prior **`torch`** module import workaround is removed.
> 
> Regression tests force **`model_rebuild(force=True)`** on both configured architecture models and assert invalid `config` values still raise **`ValidationError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13d1061ffe38e651c8f616decf9ab048720d4a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->